### PR TITLE
Add an option to stop CPAN::Meta from converting the read in metadata.

### DIFF
--- a/lib/CPAN/Meta.pm
+++ b/lib/CPAN/Meta.pm
@@ -203,15 +203,27 @@ fixable errors will be handled by CPAN::Meta::Converter before validation.
 (Note that this might result in invalid optional data being silently
 dropped.)  The default is false.
 
+=item *
+
+convert -- if true, it will convert the metadata to version 2.
+The default is true.
+
 =back
 
 =cut
 
+my $defaults = {
+    lazy_validation     => 0,
+    convert             => 1
+};
 sub _new {
   my ($class, $struct, $options) = @_;
   my $self;
 
-  if ( $options->{lazy_validation} ) {
+  # Add default options
+  $options = {%$defaults, %{$options||{}}};
+
+  if ( $options->{lazy_validation} && $options->{convert} ) {
     # try to convert to a valid structure; if succeeds, then return it
     my $cmc = CPAN::Meta::Converter->new( $struct );
     $self = $cmc->convert( version => 2 ); # valid or dies
@@ -228,7 +240,7 @@ sub _new {
 
   # up-convert older spec versions
   my $version = $struct->{'meta-spec'}{version} || '1.0';
-  if ( $version == 2 ) {
+  if ( $version == 2 || !$options->{convert} ) {
     $self = $struct;
   }
   else {

--- a/t/load.t
+++ b/t/load.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+
+use CPAN::Meta;
+use File::Spec;
+use IO::Dir;
+
+sub _slurp { do { local(@ARGV,$/)=shift(@_); <> } }
+
+note "convert metafile"; {
+    my $meta = CPAN::Meta->load_file("t/data/META-1_4.yml");
+    is $meta->{"meta-spec"}{version}, 2;
+
+    $meta = CPAN::Meta->load_file("t/data/META-1_4.yml", {lazy_validation => 0});
+    is $meta->{"meta-spec"}{version}, 2, "no lazy valiation";
+}
+
+
+note "don't convert"; {
+    my $meta = CPAN::Meta->load_file("t/data/META-1_4.yml", { convert => 0 });
+    is $meta->{"meta-spec"}{version}, 1.4;
+
+    $meta = CPAN::Meta->load_file("t/data/META-1_4.yml", {lazy_validation => 0, convert => 0});
+    is $meta->{"meta-spec"}{version}, 1.4, "no lazy valiation";
+}
+
+
+done_testing;


### PR DESCRIPTION
This adds a "convert" option to CPAN::Meta->new which can be set to false to prevent it from converting the metadata.

After I did it I realized I can use Parse::CPAN::Meta, but I still think it's a worthwhile option at the CPAN::Meta level.
