### PR TITLE
Added requested_version to CPAN::Meta::Requirments

### DIFF
--- a/lib/CPAN/Meta/Requirements.pm
+++ b/lib/CPAN/Meta/Requirements.pm
@@ -250,6 +250,22 @@ specified.
 
 =cut
 
+sub requested_version {
+	my ($self, $module) = @_;
+	my $entry = $self->__entry_for($module);
+	return $entry ? $entry->as_string : undef;
+}
+
+=method requested_version
+
+  $req->requested_version( $module );
+
+This returns the required version for a given module. This should be used for
+informational purposes such as error message only and should not be
+interpreted in any way.
+
+=cut
+
 sub required_modules { keys %{ $_[0]{requirements} } }
 
 =method clone

--- a/t/prereqs.t
+++ b/t/prereqs.t
@@ -61,6 +61,7 @@ is_deeply($prereq->as_string_hash, $prereq_struct, "round-trip okay");
     (! grep { 'Test' eq $_ } @req_mod),
     "...nor the build requirements",
   );
+  is($req->requested_version('perl'), '5.005_03', 'Requires perl 5.005_03');
 }
 
 {
@@ -85,6 +86,8 @@ is_deeply($prereq->as_string_hash, $prereq_struct, "round-trip okay");
     (! grep { 'Test' eq $_ } @req_mod),
     "...but not the build requirements",
   );
+
+  is($rec->requested_version('ExtUtils::ParseXS'), '2.02', 'recommends ExtUtils');
 }
 
 {


### PR DESCRIPTION
This is useful for giving user-friendly error messages. Pulling it out of the string hash just feels dirty.
