### PR TITLE
Recognize version attributes in provides hash

### DIFF
--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -693,10 +693,12 @@ sub _release_status_from_version {
 
 my $provides_spec = {
   file => \&_keep,
+  version => &_keep,
 };
 
 my $provides_spec_2 = {
   file => \&_keep,
+  version => &_keep,
   ':custom'  => \&_prefix_custom,
 };
 


### PR DESCRIPTION
The current lack of recognision causes erroneous results, and combined with the recent versioning fix breaks Module::Build, see also rt#84271.
