### PR TITLE
remove x_ from custom resources while downgrading

### DIFF
--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -97,6 +97,12 @@ sub _ucfirst_custom {
   return $key;
 }
 
+sub _no_prefix_ucfirst_custom {
+  my $key = shift;
+  $key =~ s/^x_//;
+  return _ucfirst_custom($key);
+}
+
 sub _change_meta_spec {
   my ($element, undef, undef, $version) = @_;
   $element->{version} = $version;
@@ -670,7 +676,7 @@ my $resource_downgrade_spec = {
   homepage   => \&_url_or_drop,
   bugtracker => sub { return $_[0]->{web} },
   repository => sub { return $_[0]->{url} || $_[0]->{web} },
-  ':custom'  => \&_ucfirst_custom,
+  ':custom'  => \&_no_prefix_ucfirst_custom,
 };
 
 sub _downgrade_resources {


### PR DESCRIPTION
The following script demonstrates this issue. Without this fix you'll see an error like this: `Resource 'x_MailingList' must be in CamelCase. (resources -> x_MailingList)`. See also ExtUtils::MakeMaker (https://metacpan.org/source/BINGOS/ExtUtils-MakeMaker-6.66/META.yml) and its Makefile.PL (https://metacpan.org/source/BINGOS/ExtUtils-MakeMaker-6.66/Makefile.PL) for a live example.

``` perl
use strict;
use warnings;
use CPAN::Meta;
use File::Temp;
use Test::More;
use Test::CPAN::Meta;

my $yaml = <<'YAML';

---
author:
  - A.U.Thor
abstract: shows an issue on downgrading resources
generated_by: 'ExtUtils::MakeMaker version 6.62, CPAN::Meta::Converter version 2.112621'
license: perl
meta-spec:
  url: http://module-build.sourceforge.net/META-spec-v1.4.html
  version: 1.4
name: Resource-Conversion-Test
resources:
  MailingList: some@mailing.list
version: 0.01
YAML

my $meta = CPAN::Meta->load_yaml_string($yaml);
my $tmpdir = File::Temp->newdir(CLEANUP => 1);
my $tmpfile = "$tmpdir/META.yml";
open my $fh, '>', $tmpfile or die $!;
print $fh $meta->as_string({version => '1.4'});
close $fh;

meta_spec_ok($tmpfile, 1.4);
done_testing;
```
