### PR TITLE
add conflicts checking in Makefile.PL for versions of Dist::Zilla that p...

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for CPAN-Meta
 
 {{$NEXT}}
+  - added check at install time for conflicting versions of Dist::Zilla, that
+    produce non-compliant meta files
 
 2.132620  2013-09-19 11:18:33 America/New_York
 

--- a/dist.ini
+++ b/dist.ini
@@ -37,3 +37,8 @@ CPAN::Meta::YAML = 0.008
 [OnlyCorePrereqs]
 starting_version = current
 phase = test
+
+[Conflicts]
+; versions before 4.300039 generate license and other fields as a scalar,
+; not an arrayref
+Dist::Zilla = 4.300038


### PR DESCRIPTION
...roduce invalid data

These warnings usually don't get seen anyway, but it can still be useful, and each downstream dep with conflicts support recursively checks all the way up the line, so this can help point out to the user that new CPAN::Meta and not-latest Dist::Zilla are incompatible with each other.
