### PR TITLE
make sure $meta->{'meta-spec'}{version} returns a valid version

### DIFF
--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -1226,7 +1226,7 @@ sub new {
   # create an attributes hash
   my $self = {
     'data'    => $data,
-    'spec'    => $data->{'meta-spec'}{'version'} || "1.0",
+    'spec'    => eval { $data->{'meta-spec'}{'version'} || "1.0" } || 0,
   };
 
   # create the object

--- a/lib/CPAN/Meta/Validator.pm
+++ b/lib/CPAN/Meta/Validator.pm
@@ -451,7 +451,7 @@ sub new {
   # create an attributes hash
   my $self = {
     'data'    => $data,
-    'spec'    => $data->{'meta-spec'}{'version'} || "1.0",
+    'spec'    => eval { $data->{'meta-spec'}{'version'} || "1.0" } || 0,
     'errors'  => undef,
   };
 

--- a/t/converter-fail.t
+++ b/t/converter-fail.t
@@ -14,7 +14,7 @@ delete $ENV{$_} for qw/PERL_JSON_BACKEND PERL_YAML_BACKEND/; # use defaults
 my $data_dir = IO::Dir->new( 't/data-fail' );
 my @files = sort grep { /^\w/ } $data_dir->read;
 
-sub _spec_version { return $_[0]->{'meta-spec'}{version} || "1.0" }
+sub _spec_version { return eval { $_[0]->{'meta-spec'}{version} || "1.0" } || 0}
 
 use Data::Dumper;
 

--- a/t/data-fail/1120170767-META.yml
+++ b/t/data-fail/1120170767-META.yml
@@ -1,0 +1,25 @@
+# http://module-build.sourceforge.net/META-spec-new.html
+#XXXXXXX This is a prototype!!!  It will change in the future!!! XXXXX#
+meta-spec:    1.1
+name:         XML-Writer
+version:      0.600
+abstract:     Easily generate well-formed, namespace-aware XML.
+authored_by:
+  - David Megginson <david@megginson.com>
+  - Ed Avis <ed@membled.com>
+  - Joseph Walton <joe@kafsemo.org>
+license:      perl
+distribution_type: module
+installdirs:  site
+
+build_requires:
+  perl: 5.006_000
+recommends:
+  perl: 5.008_001
+
+no_index:
+  package:
+    - XML::Writer::Namespaces
+
+dynamic_config: 0
+generated_by: Hand


### PR DESCRIPTION
- as it dies abruptly when $meta->{'meta-spec'} illegally returns a scalar spec version (example: JOSEPHW/XML-Writer-0.600.tar.gz)
