### PR TITLE
Upconvert is_lax versions in conflicts during conversions

### DIFF
--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -376,6 +376,18 @@ sub _bad_version_hook {
   return defined($vobj) ? $vobj : version->parse(0); # or give up
 }
 
+sub _version_map_concise {
+  my ( $element ) = @_;
+  return unless defined $element;
+  my $hash = _version_map( $element );
+  return unless $hash;
+  for my $module ( keys %{$hash} ) {
+      next unless version::is_lax($hash->{$module});
+      $hash->{$module} = '>= ' . $hash->{$module};
+  }
+  return $hash;
+}
+
 sub _version_map {
   my ($element) = @_;
   return unless defined $element;
@@ -438,7 +450,7 @@ my $relation_spec = {
   requires   => \&_version_map,
   recommends => \&_version_map,
   suggests   => \&_version_map,
-  conflicts  => \&_version_map,
+  conflicts  => \&_version_map_concise,
   ':custom'  => \&_prefix_custom,
 };
 

--- a/t/converter.t
+++ b/t/converter.t
@@ -295,4 +295,26 @@ sub _normalize_reqs {
   );
 }
 
+# specific test for upconverting ambiguous conflict declarations
+{
+  my $file = 'ambiguous-conflict.json';
+  my $path = File::Spec->catfile('t','data-test',$file);
+  my $original = Parse::CPAN::Meta->load_file( $path  );
+  ok( $original, "loaded $file" );
+  my $cmc = CPAN::Meta::Converter->new( $original );
+  my $cleaned_up = $cmc->convert( version => "2" );
+  is_deeply(
+      $cleaned_up->{prereqs},
+      {
+          runtime => {
+              conflicts => {
+                  "Data::Dumper" => ">= 1",
+                  "Explicit::Module::Newer" => ">= 2",
+                  "Explicit::Module::Older" => "<= 3",
+              }
+          }
+      },
+      "Data::Dumper : 1  means Data::Dumper >=1 "
+  );
+}
 done_testing;

--- a/t/data-test/ambiguous-conflict.json
+++ b/t/data-test/ambiguous-conflict.json
@@ -1,0 +1,29 @@
+{
+   "generated_by" : "Module::Build version 0.36",
+   "meta-spec" : {
+      "version" : "2",
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+   },
+   "abstract" : "stuff",
+   "version" : "0.36",
+   "name" : "Module-Build",
+   "dynamic_config" : 1,
+   "author" : [
+      "Ken Williams <kwilliams@cpan.org>",
+      "Module-Build List <module-build@perl.org>"
+   ],
+   "release_status" : "stable",
+   "license" : [
+      "perl_5"
+   ],
+   "description" : "Module::Build is a system for building, testing, and installing Perl modules.  It is meant to be an alternative to ExtUtils::MakeMaker... blah blah blah",
+   "prereqs" : {
+      "runtime" : {
+         "conflicts" : {
+            "Data::Dumper" : "1",
+            "Explicit::Module::Newer" : ">=2",
+            "Explicit::Module::Older" : "<=3"
+         }
+      }
+   }
+}


### PR DESCRIPTION
A partial solution for #55 , make sure converted meta files emit 

```json
{ 
  "conflicts": {
    "Foo" : 1
  }
}
```

And equivalent as 
```json
{ 
  "conflicts": {
    "Foo" : ">=1"
  }
}
```

To clarify the implicit semantics.

Also note: Currently ">=1" is normalised to just "1" by default with `CPAN::Meta::Requirements`

```perl
use Data::Dumper;
use CPAN::Meta::Requirements;
my $x = CPAN::Meta::Requirements->new(); 
$x->add_string_requirement( Foo => q[>=1] );
print Dumper($x->as_string_hash);
__END__
$VAR1 = {
          'Foo' => '1'
        };

```

And this issue is avoided by processing the return value from `CPAN::Meta::Requirements`.

Subsequent munging of this value outside `CPAN::Meta::Converter` will likely lose the `>=` context.

Additionally, this patch introduces a test failure I haven't understood yet:
```TAP
t/converter.t ............ 13/? 
#   Failed test 'downconversion from 2 merge test and build requirements'
#   at t/converter.t line 75.
#     Structures begin differing at:
#          $got->{Build::Requires} = Does not exist
#     $expected->{Build::Requires} = '1.1'
# Looks like you failed 1 test of 191.
```

