### PR TITLE
Exclude dependency to List::Util v1.33

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,6 @@ requires "CPAN::Meta::Requirements" => "2.121";
 requires "CPAN::Meta::YAML" => "0.008";
 requires "Carp" => "0";
 requires "JSON::PP" => "2.27200";
-requires "List::Util" => "1.33";
 requires "Parse::CPAN::Meta" => "1.4414";
 requires "Scalar::Util" => "0";
 requires "perl" => "5.008";

--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -26,7 +26,6 @@ use CPAN::Meta::Validator;
 use CPAN::Meta::Requirements;
 use version 0.88 ();
 use Parse::CPAN::Meta 1.4400 ();
-use List::Util 1.33 qw/all/;
 
 sub _dclone {
   my $ref = shift;
@@ -249,11 +248,11 @@ sub _downgrade_license {
   }
   elsif( ref $element eq 'ARRAY' ) {
     if ( @$element > 1) {
-      if ( all { $is_open_source{ $license_downgrade_map{lc $_} || 'unknown' } } @$element ) {
-        return 'open_source';
+      if (grep { !$is_open_source{ $license_downgrade_map{lc $_} || 'unknown' } } @$element) {
+        return 'unknown';
       }
       else {
-        return 'unknown';
+        return 'open_source';
       }
     }
     elsif ( @$element == 1 ) {


### PR DESCRIPTION
Now, CPAN::Meta::Converter depends on List::Util version 1.33. 
Prior to perl-v5.19.3, that is not a core module. So occur some problems.

Therefore I exclude dependency to that.

Please refer: https://github.com/miyagawa/cpanminus/pull/372
