### PR TITLE
inlined license information in historical copies of spec

### DIFF
--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -17,6 +17,11 @@ Modifications from the original:
 
 Conversion from the original HTML to POD format
 
+=item *
+
+Include list of valid licenses from L<Module::Build> 0.17 rather than
+linking to the module.
+
 =back
 
 =head1 DESCRIPTION
@@ -71,8 +76,56 @@ The version of the distribution to which the META.yml file refers.
 Example: C<perl>
 
 The license under which this distribution may be used and
-redistributed.  See L<Module::Build> for the list of valid options.
+redistributed.
 
+Must be one of the following licenses:
+
+=over 4
+
+=item perl
+
+The distribution may be copied and redistributed under the same terms as perl
+itself (this is by far the most common licensing option for modules on CPAN).
+This is a dual license, in which the user may choose between either the GPL or
+the Artistic license.
+
+=item gpl
+
+The distribution is distributed under the terms of the Gnu General Public
+License (L<http://www.opensource.org/licenses/gpl-license.php>).
+
+=item lgpl
+
+The distribution is distributed under the terms of the Gnu Lesser General
+Public License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+
+=item artistic
+
+The distribution is licensed under the Artistic License, as specified by the
+Artistic file in the standard perl distribution.
+
+=item bsd
+
+The distribution is licensed under the BSD License
+(L<http://www.opensource.org/licenses/bsd-license.php>).
+
+=item open_source
+
+The distribution is licensed under some other Open Source Initiative-approved
+license listed at L<http://www.opensource.org/licenses/>.
+
+=item unrestricted
+
+The distribution is licensed under a license that is B<not> approved by
+L<www.opensource.org|http://www.opensource.org> but that allows distribution
+without restrictions.
+
+=item restrictive
+
+The distribution may not be redistributed without special permission from the
+author and/or copyright holder.
+
+=back
 
 =item distribution_type
 

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -17,6 +17,11 @@ Modifications from the original:
 
 Conversion from the original HTML to POD format
 
+=item *
+
+Include list of valid licenses from L<Module::Build> 0.18 rather than
+linking to the module.
+
 =back
 
 =head1 DESCRIPTION
@@ -86,8 +91,56 @@ a descriptive term for the licenses ... not authoritative, but must
 be consistent with licensure statements in the READMEs, documentation, etc.
 
 The license under which this distribution may be used and
-redistributed.  See L<Module::Build>
-for the list of valid options.
+redistributed.
+
+Must be one of the following licenses:
+
+=over 4
+
+=item perl
+
+The distribution may be copied and redistributed under the same terms as perl
+itself (this is by far the most common licensing option for modules on CPAN).
+This is a dual license, in which the user may choose between either the GPL or
+the Artistic license.
+
+=item gpl
+
+The distribution is distributed under the terms of the Gnu General Public
+License (L<http://www.opensource.org/licenses/gpl-license.php>).
+
+=item lgpl
+
+The distribution is distributed under the terms of the Gnu Lesser General
+Public License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+
+=item artistic
+
+The distribution is licensed under the Artistic License, as specified by the
+Artistic file in the standard perl distribution.
+
+=item bsd
+
+The distribution is licensed under the BSD License
+(L<http://www.opensource.org/licenses/bsd-license.php>).
+
+=item open_source
+
+The distribution is licensed under some other Open Source Initiative-approved
+license listed at L<http://www.opensource.org/licenses/>.
+
+=item unrestricted
+
+The distribution is licensed under a license that is B<not> approved by
+L<www.opensource.org|http://www.opensource.org> but that allows distribution
+without restrictions.
+
+=item restrictive
+
+The distribution may not be redistributed without special permission from the
+author and/or copyright holder.
+
+=back
 
 =item license_uri
 

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -17,6 +17,11 @@ Modifications from the original:
 
 Various spelling corrections
 
+=item *
+
+Include list of valid licenses from L<Module::Build> 0.2611 rather than
+linking to the module.
+
 =back
 
 =head1 SYNOPSIS
@@ -226,8 +231,56 @@ Example:
   license: perl
 
 (Spec 1.0) [required] {string} The license under which this distribution may be
-used and redistributed.  See L<Module::Build> for the list of valid
-options.
+used and redistributed.
+
+Must be one of the following licenses:
+
+=over 4
+
+=item perl
+
+The distribution may be copied and redistributed under the same terms as perl
+itself (this is by far the most common licensing option for modules on CPAN).
+This is a dual license, in which the user may choose between either the GPL or
+the Artistic license.
+
+=item gpl
+
+The distribution is distributed under the terms of the Gnu General Public
+License (L<http://www.opensource.org/licenses/gpl-license.php>).
+
+=item lgpl
+
+The distribution is distributed under the terms of the Gnu Lesser General
+Public License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+
+=item artistic
+
+The distribution is licensed under the Artistic License, as specified by the
+Artistic file in the standard perl distribution.
+
+=item bsd
+
+The distribution is licensed under the BSD License
+(L<http://www.opensource.org/licenses/bsd-license.php>).
+
+=item open_source
+
+The distribution is licensed under some other Open Source Initiative-approved
+license listed at L<http://www.opensource.org/licenses/>.
+
+=item unrestricted
+
+The distribution is licensed under a license that is B<not> approved by
+L<www.opensource.org|http://www.opensource.org> but that allows distribution
+without restrictions.
+
+=item restrictive
+
+The distribution may not be redistributed without special permission from the
+author and/or copyright holder.
+
+=back
 
 =head2 distribution_type
 

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -17,6 +17,11 @@ Modifications from the original:
 
 Various spelling corrections
 
+=item *
+
+Include list of valid licenses from L<Module::Build> 0.2805 rather than
+linking to the module.
+
 =back
 
 =head1 SYNOPSIS
@@ -192,8 +197,72 @@ Example:
   license: perl
 
 (Spec 1.0) [required] {string} The license under which this distribution may be
-used and redistributed.  See L<Module::Build> for the list of valid
-options.
+used and redistributed.
+
+Must be one of the following licenses:
+
+=over 4
+
+=item apache
+
+The distribution is licensed under the Apache Software License
+(L<http://opensource.org/licenses/apachepl.php>).
+
+=item artistic
+
+The distribution is licensed under the Artistic License, as specified by the
+Artistic file in the standard perl distribution.
+
+=item bsd
+
+The distribution is licensed under the BSD License
+(L<http://www.opensource.org/licenses/bsd-license.php>).
+
+=item gpl
+
+The distribution is licensed under the terms of the Gnu General Public License
+(L<http://www.opensource.org/licenses/gpl-license.php>).
+
+=item lgpl
+
+The distribution is licensed under the terms of the Gnu Lesser General Public
+License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+
+=item mit
+
+The distribution is licensed under the MIT License
+(L<http://opensource.org/licenses/mit-license.php>).
+
+=item mozilla
+
+The distribution is licensed under the Mozilla Public License.
+(L<http://opensource.org/licenses/mozilla1.0.php> or
+L<http://opensource.org/licenses/mozilla1.1.php>)
+
+=item open_source
+
+The distribution is licensed under some other Open Source Initiative-approved
+license listed at L<http://www.opensource.org/licenses/>.
+
+=item perl
+
+The distribution may be copied and redistributed under the same terms as perl
+itself (this is by far the most common licensing option for modules on CPAN).
+This is a dual license, in which the user may choose between either the GPL or
+the Artistic license.
+
+=item restrictive
+
+The distribution may not be redistributed without special permission from the
+author and/or copyright holder.
+
+=item unrestricted
+
+The distribution is licensed under a license that is not approved by
+L<www.opensource.org|http://www.opensource.org/> but that allows distribution
+without restrictions.
+
+=back
 
 =head2 distribution_type
 

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -17,6 +17,11 @@ Modifications from the original:
 
 Various spelling corrections
 
+=item *
+
+Include list of valid licenses from L<Module::Build> 0.2807 rather than
+linking to the module.
+
 =back
 
 =head1 SYNOPSIS
@@ -221,9 +226,72 @@ Example:
   license: perl
 
 (Spec 1.0) [required] {string} The license under which this
-distribution may be used and redistributed.  See
-L<http://search.cpan.org/dist/Module-Build/lib/Module/Build/API.pod>
-for the list of valid options.
+distribution may be used and redistributed.
+
+Must be one of the following licenses:
+
+=over 4
+
+=item apache
+
+The distribution is licensed under the Apache Software License
+(L<http://opensource.org/licenses/apachepl.php>).
+
+=item artistic
+
+The distribution is licensed under the Artistic License, as specified by the
+Artistic file in the standard perl distribution.
+
+=item bsd
+
+The distribution is licensed under the BSD License
+(L<http://www.opensource.org/licenses/bsd-license.php>).
+
+=item gpl
+
+The distribution is licensed under the terms of the Gnu General Public License
+(L<http://www.opensource.org/licenses/gpl-license.php>).
+
+=item lgpl
+
+The distribution is licensed under the terms of the Gnu Lesser General Public
+License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+
+=item mit
+
+The distribution is licensed under the MIT License
+(L<http://opensource.org/licenses/mit-license.php>).
+
+=item mozilla
+
+The distribution is licensed under the Mozilla Public License.
+(L<http://opensource.org/licenses/mozilla1.0.php> or
+L<http://opensource.org/licenses/mozilla1.1.php>)
+
+=item open_source
+
+The distribution is licensed under some other Open Source Initiative-approved
+license listed at L<http://www.opensource.org/licenses/>.
+
+=item perl
+
+The distribution may be copied and redistributed under the same terms as perl
+itself (this is by far the most common licensing option for modules on CPAN).
+This is a dual license, in which the user may choose between either the GPL or
+the Artistic license.
+
+=item restrictive
+
+The distribution may not be redistributed without special permission from the
+author and/or copyright holder.
+
+=item unrestricted
+
+The distribution is licensed under a license that is not approved by
+L<www.opensource.org|http://www.opensource.org/> but that allows distribution
+without restrictions.
+
+=back
 
 =head2 distribution_type
 


### PR DESCRIPTION
Replace links to Module::Build with full list of valid licenses, taken from the latest version at the time the spec was published.
