### PR TITLE
Prefer stringify over normal for alpha only

### DIFF
--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -378,7 +378,7 @@ sub _clean_version {
   # XXX check defined $v and not just $v because version objects leak memory
   # in boolean context -- dagolden, 2012-02-03
   if ( defined $v ) {
-    return _is_qv($v) ? $v->normal : $element;
+    return $v->is_alpha ? $v->stringify : _is_qv($v) ? $v->normal : $element;
   }
   else {
     return 0;


### PR DESCRIPTION
Revised proposed change; only uses stringify for alpha versions.