### PR TITLE
Less cryptic error when a necessary interface is missing

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,7 @@ match = ^t/data-
 :version = 0.070
 -remove = MakeMaker
 -remove = PodWeaver
+-remove = PkgVersion
 auto_version = 1
 authority = cpan:DAGOLDEN
 no_minimum_perl = 1
@@ -30,6 +31,11 @@ stopwords = metacpan
 stopwords = releaser
 stopwords = subkey
 stopwords = subkeys
+
+[RewriteVersion]
+skip_version_provider = 1
+
+[BumpVersionAfterRelease]
 
 [SurgicalPodWeaver]
 :version = 0.0021

--- a/lib/CPAN/Meta.pm
+++ b/lib/CPAN/Meta.pm
@@ -2,7 +2,8 @@ use 5.006;
 use strict;
 use warnings;
 package CPAN::Meta;
-# VERSION
+
+our $VERSION = '2.143241';
 
 =head1 SYNOPSIS
 

--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -2,7 +2,8 @@ use 5.006;
 use strict;
 use warnings;
 package CPAN::Meta::Converter;
-# VERSION
+
+our $VERSION = '2.143241';
 
 =head1 SYNOPSIS
 

--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -1462,6 +1462,8 @@ Returns a new hash reference with the metadata converted to the latest version
 of the CPAN Meta Spec.  No validation is done on the result -- you must
 validate after merging fragments into a complete metadata document.
 
+Available since version 2.141170.
+
 =cut
 
 sub upgrade_fragment {

--- a/lib/CPAN/Meta/Feature.pm
+++ b/lib/CPAN/Meta/Feature.pm
@@ -2,7 +2,8 @@ use 5.006;
 use strict;
 use warnings;
 package CPAN::Meta::Feature;
-# VERSION
+
+our $VERSION = '2.143241';
 
 use CPAN::Meta::Prereqs;
 

--- a/lib/CPAN/Meta/History.pm
+++ b/lib/CPAN/Meta/History.pm
@@ -3,7 +3,8 @@ use 5.006;
 use strict;
 use warnings;
 package CPAN::Meta::History;
-# VERSION
+
+our $VERSION = '2.143241';
 
 1;
 

--- a/lib/CPAN/Meta/Merge.pm
+++ b/lib/CPAN/Meta/Merge.pm
@@ -2,7 +2,8 @@ use strict;
 use warnings;
 
 package CPAN::Meta::Merge;
-# VERSION
+
+our $VERSION = '2.143241';
 
 use Carp qw/croak/;
 use Scalar::Util qw/blessed/;

--- a/lib/CPAN/Meta/Merge.pm
+++ b/lib/CPAN/Meta/Merge.pm
@@ -6,7 +6,7 @@ package CPAN::Meta::Merge;
 
 use Carp qw/croak/;
 use Scalar::Util qw/blessed/;
-use CPAN::Meta::Converter;
+use CPAN::Meta::Converter 2.141170;
 
 sub _identical {
   my ($left, $right, $path) = @_;

--- a/lib/CPAN/Meta/Prereqs.pm
+++ b/lib/CPAN/Meta/Prereqs.pm
@@ -2,7 +2,8 @@ use 5.006;
 use strict;
 use warnings;
 package CPAN::Meta::Prereqs;
-# VERSION
+
+our $VERSION = '2.143241';
 
 =head1 DESCRIPTION
 

--- a/lib/CPAN/Meta/Spec.pm
+++ b/lib/CPAN/Meta/Spec.pm
@@ -7,7 +7,8 @@ use 5.006;
 use strict;
 use warnings;
 package CPAN::Meta::Spec;
-# VERSION
+
+our $VERSION = '2.143241';
 
 1;
 

--- a/lib/CPAN/Meta/Validator.pm
+++ b/lib/CPAN/Meta/Validator.pm
@@ -2,7 +2,8 @@ use 5.006;
 use strict;
 use warnings;
 package CPAN::Meta::Validator;
-# VERSION
+
+our $VERSION = '2.143241';
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
document availability of upgrade_fragment; assert minimum version needed for upgrade_fragment()
    
If this distribution is downgraded to before CPAN::Meta::Merge existed, other
code depending on CPAN::Meta::Merge won't know that other required components
are missing. Adding the version check gives a less cryptic error message.

Because the code now requires a local module to have a version, I've added $VERSION assignments
and [RewriteVersion], [BumpVersionAfterRelease]. It's quite fine to use these together with [AutoVersion]
if we prevent [RewriteVersion] from providing the dummy version used in the repo; I also removed
[PkgVersion] to avoid "skipping..." warnings.