### PR TITLE
Update to merge algorithm for deep hashes

### DIFF
--- a/lib/CPAN/Meta.pm
+++ b/lib/CPAN/Meta.pm
@@ -657,3 +657,4 @@ existing test-file that illustrates the bug or desired feature.
 
 =cut
 
+# vim: ts=2 sts=2 sw=2 et :

--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -1500,4 +1500,4 @@ existing test-file that illustrates the bug or desired feature.
 
 =cut
 
-# vim: ts=2 sts=2 sw=2 et:
+# vim: ts=2 sts=2 sw=2 et :

--- a/lib/CPAN/Meta/Feature.pm
+++ b/lib/CPAN/Meta/Feature.pm
@@ -80,4 +80,4 @@ existing test-file that illustrates the bug or desired feature.
 
 =cut
 
-
+# vim: ts=2 sts=2 sw=2 et :

--- a/lib/CPAN/Meta/Merge.pm
+++ b/lib/CPAN/Meta/Merge.pm
@@ -237,3 +237,7 @@ that allows one to add additional merging functions for specific elements.
 
 Merge all C<@fragments> together. It will accept both CPAN::Meta objects and
 (possibly incomplete) hashrefs of metadata.
+
+=cut
+
+# vim: ts=2 sts=2 sw=2 et :

--- a/lib/CPAN/Meta/Merge.pm
+++ b/lib/CPAN/Meta/Merge.pm
@@ -59,6 +59,13 @@ sub _uniq_map {
     if (not exists $left->{$key}) {
       $left->{$key} = $right->{$key};
     }
+    # identical strings or references are merged identically
+    elsif (_is_identical($left->{$key}, $right->{$key})) {
+      1; # do nothing - keep left
+    }
+    elsif (ref $left->{$key} eq 'HASH' and ref $right->{$key} eq 'HASH') {
+      $left->{$key} = _uniq_map($left->{$key}, $right->{$key}, [ @{$path}, $key ]);
+    }
     else {
       croak 'Duplication of element ' . join '.', @{$path}, $key;
     }

--- a/lib/CPAN/Meta/Merge.pm
+++ b/lib/CPAN/Meta/Merge.pm
@@ -9,9 +9,18 @@ use Carp qw/croak/;
 use Scalar::Util qw/blessed/;
 use CPAN::Meta::Converter 2.141170;
 
+sub _is_identical {
+  my ($left, $right) = @_;
+  return
+    (not defined $left and not defined $right)
+    # if either of these are references, we compare the serialized value
+    || (defined $left and defined $right and $left eq $right);
+}
+
 sub _identical {
   my ($left, $right, $path) = @_;
-  croak sprintf "Can't merge attribute %s: '%s' does not equal '%s'", join('.', @{$path}), $left, $right unless $left eq $right;
+  croak sprintf "Can't merge attribute %s: '%s' does not equal '%s'", join('.', @{$path}), $left, $right
+    unless _is_identical($left, $right);
   return $left;
 }
 

--- a/lib/CPAN/Meta/Prereqs.pm
+++ b/lib/CPAN/Meta/Prereqs.pm
@@ -288,4 +288,4 @@ existing test-file that illustrates the bug or desired feature.
 
 =cut
 
-
+# vim: ts=2 sts=2 sw=2 et :

--- a/lib/CPAN/Meta/Validator.pm
+++ b/lib/CPAN/Meta/Validator.pm
@@ -1004,4 +1004,4 @@ existing test-file that illustrates the bug or desired feature.
 
 =cut
 
-
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/converter-bad.t
+++ b/t/converter-bad.t
@@ -73,4 +73,4 @@ for my $f ( reverse sort @files ) {
 }
 
 done_testing;
-
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/converter-fail.t
+++ b/t/converter-fail.t
@@ -38,4 +38,4 @@ for my $f ( reverse sort @files ) {
 }
 
 done_testing;
-
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/converter-fragments.t
+++ b/t/converter-fragments.t
@@ -151,7 +151,7 @@ for my $c (@cases) {
     my $got = $cmc->upgrade_fragment;
     my $exp = $c->{expect};
     is_deeply( $got, $exp, $c->{label} )
-      or diag "GOT:\n" . explain($got) . "\nEXPECTED:\n" . explain($exp);
+      or diag "GOT:\n", explain($got), "EXPECTED:\n", explain($exp);
 }
 
 done_testing;

--- a/t/converter-fragments.t
+++ b/t/converter-fragments.t
@@ -155,4 +155,4 @@ for my $c (@cases) {
 }
 
 done_testing;
-# vim: ts=4 sts=4 sw=4 et:
+# vim: ts=8 sts=4 sw=4 et :

--- a/t/converter.t
+++ b/t/converter.t
@@ -305,3 +305,4 @@ sub _normalize_reqs {
 }
 
 done_testing;
+# vim: ts=2 sts=2 sw=2 et:

--- a/t/load-bad.t
+++ b/t/load-bad.t
@@ -15,12 +15,10 @@ my @files = sort grep { /^\w/ } $data_dir->read;
 
 for my $f ( sort @files ) {
   my $path = File::Spec->catfile('t','data-fixable',$f);
-  my $meta = eval { CPAN::Meta->load_file( $path ) };
-  ok( defined $meta, "load_file('$f')" ) or diag $@;
+  ok( eval { CPAN::Meta->load_file( $path ) }, "load_file('$f')" ) or diag $@;
   my $string = _slurp($path);
   my $method =  $path =~ /\.json/ ? "load_json_string" : "load_yaml_string";
-  my $meta2 = eval { CPAN::Meta->$method( $string, { fix_errors => 1 } ) };
-  ok( defined $meta2, "$method(slurp('$f'))" ) or diag $@;
+  ok( eval { CPAN::Meta->$method( $string, { fix_errors => 1 } ) }, "$method(slurp('$f'))" ) or diag $@;
 }
 
 done_testing;

--- a/t/load-bad.t
+++ b/t/load-bad.t
@@ -22,4 +22,4 @@ for my $f ( sort @files ) {
 }
 
 done_testing;
-
+# vim: ts=2 sts=2 sw=2 et:

--- a/t/merge.t
+++ b/t/merge.t
@@ -1,5 +1,3 @@
-#! perl
-
 use strict;
 use warnings;
 

--- a/t/merge.t
+++ b/t/merge.t
@@ -106,12 +106,18 @@ my $first_result = $merger->merge(\%base, \%first);
 is_deeply($first_result, \%first_expected, 'First result is as expected');
 
 is_deeply($merger->merge(\%base, { abstract => 'This is a test' }), \%base, 'Can merge in identical abstract');
-my $failure = eval { $merger->merge(\%base, { abstract => 'And now for something else' }) };
-is($failure, undef, 'Trying to merge different author gives an exception');
+is(
+    eval { $merger->merge(\%base, { abstract => 'And now for something else' }) },
+    undef,
+    'Trying to merge different author gives an exception',
+);
 like $@, qr/^Can't merge attribute abstract/, 'Exception looks right';
 
-my $failure2 = eval { $merger->merge(\%base, { provides => { Baz => { file => 'Baz.pm' } } }) };
-is($failure2, undef, 'Trying to merge different author gives an exception');
+is(
+    eval { $merger->merge(\%base, { provides => { Baz => { file => 'Baz.pm' } } }) },
+    undef,
+    'Trying to merge different author gives an exception',
+);
 like $@, qr/^Duplication of element provides\.Baz /, 'Exception looks right';
 
 # issue 67

--- a/t/merge.t
+++ b/t/merge.t
@@ -126,3 +126,4 @@ my $base_obj = CPAN::Meta->create(\%base);
 ok my $first_result_obj = $merger->merge($base_obj, \%first), 'merging CPAN::Meta objects succeeds';
 
 done_testing();
+# vim: ts=4 sts=4 sw=4 tw=78 noet :

--- a/t/merge.t
+++ b/t/merge.t
@@ -100,6 +100,34 @@ my %first_expected = (
 		version => 2,
 	},
 );
+my %provides_merge_expected = (
+	abstract => 'This is a test',
+	author => ['A.U. Thor'],
+	generated_by => 'Myself',
+	license => [ 'perl_5' ],
+	resources => {
+		license => [ 'http://dev.perl.org/licenses/' ],
+		bugtracker => { web => 'https://rt.cpan.org/Dist/Display.html?Foo-Bar' },
+	},
+	prereqs => {
+		runtime => {
+			requires => {
+				Foo => '0',
+			},
+		},
+	},
+	dynamic_config => 0,
+	provides => {
+		Baz => {
+			file => 'lib/Baz.pm',
+			version => '0.001',         # same as %base, but for this extra key
+		},
+	},
+	'meta-spec' => {
+		url => "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+		version => 2,
+	},
+);
 
 my $merger = CPAN::Meta::Merge->new(default_version => '2');
 
@@ -127,7 +155,15 @@ is(
     undef,
     'Trying to merge different provides.$module.file gives an exception',
 );
-like $@, qr/^Duplication of element provides\.Baz /, 'Exception looks right';
+like $@, qr/^Duplication of element provides\.Baz\.file /, 'Exception looks right';
+
+my $provides_result = $merger->merge(\%base, { provides => { Baz => { file => 'lib/Baz.pm', version => '0.001' } } });
+is_deeply(
+	$provides_result,
+	\%provides_merge_expected,
+	'Trying to merge a new key for provides.$module is permitted; identical values are preserved',
+);
+
 
 # issue 67
 @base{qw/name version release_status/} = qw/Foo-Bar 0.01 testing/;

--- a/t/merge.t
+++ b/t/merge.t
@@ -12,6 +12,7 @@ my %base = (
 	license => [ 'perl_5' ],
 	resources => {
 		license => [ 'http://dev.perl.org/licenses/' ],
+                bugtracker => { web => 'https://rt.cpan.org/Dist/Display.html?Foo-Bar' },
 	},
 	prereqs => {
 		runtime => {
@@ -68,6 +69,7 @@ my %first_expected = (
 	license => [ 'perl_5', 'bsd' ],
 	resources => {
 		license => [ 'http://dev.perl.org/licenses/', 'http://opensource.org/licenses/bsd-license.php' ],
+                bugtracker => { web => 'https://rt.cpan.org/Dist/Display.html?Foo-Bar' },
 	},
 	prereqs => {
 		runtime => {
@@ -112,6 +114,13 @@ is(
     'Trying to merge different author gives an exception',
 );
 like $@, qr/^Can't merge attribute abstract/, 'Exception looks right';
+
+is(
+    eval { $merger->merge(\%base, { resources => { bugtracker => { web => 'http://foo.com' } } } ) },
+    undef,
+    'Trying to merge a different bugtracker URL gives an exception',
+);
+like $@, qr/^Duplication of element resources\.bugtracker\.web /, 'Exception looks right';
 
 is(
     eval { $merger->merge(\%base, { provides => { Baz => { file => 'Baz.pm' } } }) },

--- a/t/merge.t
+++ b/t/merge.t
@@ -116,7 +116,7 @@ like $@, qr/^Can't merge attribute abstract/, 'Exception looks right';
 is(
     eval { $merger->merge(\%base, { provides => { Baz => { file => 'Baz.pm' } } }) },
     undef,
-    'Trying to merge different author gives an exception',
+    'Trying to merge different provides.$module.file gives an exception',
 );
 like $@, qr/^Duplication of element provides\.Baz /, 'Exception looks right';
 

--- a/t/meta-obj.t
+++ b/t/meta-obj.t
@@ -240,3 +240,4 @@ $chk_feature->($features[0]);
 $chk_feature->( $meta->feature('domination') );
 
 done_testing;
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/no-index.t
+++ b/t/no-index.t
@@ -86,3 +86,4 @@ my %distmeta = (
 }
 
 done_testing;
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/optional_feature-merge.t
+++ b/t/optional_feature-merge.t
@@ -92,8 +92,7 @@ my $fragment3 = {
 	}
 };
 
-my $result = eval { $merger->merge($meta1, $fragment3) };
-is($result, undef, 'Trying to merge optional_features with same feature name and different descriptions gives an exception');
+is( eval { $merger->merge($meta1, $fragment3) }, undef, 'Trying to merge optional_features with same feature name and different descriptions gives an exception');
 like $@, qr/^Cannot merge two optional_features named 'FeatureName' with different 'description' values/, 'Exception looks right';
 
 my $fragment4 = {
@@ -106,8 +105,7 @@ my $fragment4 = {
 	}
 };
 
-$result = eval { $merger->merge($meta1, $fragment4) };
-is($result, undef, 'Trying to merge optional_features with same feature name and differences in other keys gives an exception');
+is( eval { $merger->merge($meta1, $fragment4) }, undef, 'Trying to merge optional_features with same feature name and differences in other keys gives an exception');
 like $@, qr/^Cannot merge two optional_features named 'FeatureName' with different 'x_default' values/, 'Exception looks right';
 
 my $fragment5 = {

--- a/t/optional_feature-merge.t
+++ b/t/optional_feature-merge.t
@@ -1,6 +1,5 @@
 use strict;
 use warnings;
-# vim: set ts=4 sw=4 noet nolist :
 
 use Test::More;
 use CPAN::Meta;
@@ -138,3 +137,4 @@ is_deeply(
 );
 
 done_testing;
+# vim: ts=4 sts=4 sw=4 noet :

--- a/t/prereqs-finalize.t
+++ b/t/prereqs-finalize.t
@@ -9,9 +9,7 @@ delete $ENV{$_} for qw/PERL_JSON_BACKEND PERL_YAML_BACKEND/; # use defaults
 sub dies_ok (&@) {
   my ($code, $qr, $comment) = @_;
 
-  my $lived = eval { $code->(); 1 };
-
-  if ($lived) {
+  if (eval { $code->(); 1 }) {
     fail("$comment: did not die");
   } else {
     like($@, $qr, $comment);

--- a/t/prereqs-finalize.t
+++ b/t/prereqs-finalize.t
@@ -89,3 +89,4 @@ $clone->requirements_for(qw(develop suggests))->add_minimum(Foo => 1);
 pass('...and we can add stuff to it');
 
 done_testing;
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/prereqs-merge.t
+++ b/t/prereqs-merge.t
@@ -104,3 +104,4 @@ is_deeply(
 );
 
 done_testing;
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/prereqs.t
+++ b/t/prereqs.t
@@ -161,4 +161,4 @@ is_deeply($prereq->as_string_hash, $prereq_struct, "round-trip okay");
 }
 
 done_testing;
-
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/repository.t
+++ b/t/repository.t
@@ -225,3 +225,4 @@ delete $ENV{$_} for qw/PERL_JSON_BACKEND PERL_YAML_BACKEND/; # use defaults
   );
 }
 done_testing;
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/save-load.t
+++ b/t/save-load.t
@@ -106,3 +106,4 @@ my $string = do { open my $fh, '<', 't/data-test/META-2.meta'; local $/; <$fh> }
 ok( $loaded = CPAN::Meta->load_string($string), 'load META-2.meta from string' );
 
 done_testing;
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/validator.t
+++ b/t/validator.t
@@ -40,4 +40,4 @@ delete $ENV{$_} for qw/PERL_JSON_BACKEND PERL_YAML_BACKEND/; # use defaults
 }
 
 done_testing;
-
+# vim: ts=2 sts=2 sw=2 et :

--- a/t/validator.t
+++ b/t/validator.t
@@ -36,6 +36,7 @@ delete $ENV{$_} for qw/PERL_JSON_BACKEND PERL_YAML_BACKEND/; # use defaults
     my $meta = Parse::CPAN::Meta->load_file( File::Spec->catfile($f) );
     my $cmv = CPAN::Meta::Validator->new({%$meta});
     ok( ! $cmv->is_valid, "$f shouldn't validate" );
+    note 'validation error: ', $_ foreach $cmv->errors;
   }
 }
 


### PR DESCRIPTION
This PR contains a few not-tightly-related cleanup items, and the final commit changes the way the `_uniq_map` merge function works: instead of borking immediately when the same hash key is found on the left and right data structures, it descends recursively into each side and tries to merge things as long as there is no conflict (duplicate values are accepted, and other non-overlapping keys are accepted).  I can't think of a case where this would be the wrong thing to do.

(I also need it for pending dzil work where multiple plugins populate non-overlapping keys in meta `provides`.)

(Note that "final commit" means the final commit in the branch -- which is not the ordering that github shows here, because I rebased the commits to use a more sensible ordering. Thanks, github.) :p