### PR TITLE
add x_serialization_backend entry

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for CPAN-Meta
 
 {{$NEXT}}
 
+  [CHANGED]
+
+  - Serialized CPAN::Meta objects now include a x_serialization_backend
+    entry
+
 2.150002  2015-04-19 01:00:10+02:00 Europe/Berlin (TRIAL RELEASE)
 
   [CHANGED]

--- a/lib/CPAN/Meta.pm
+++ b/lib/CPAN/Meta.pm
@@ -591,6 +591,10 @@ JSON.  For C<version> less than 2, the string will be serialized as YAML.  In
 both cases, the same rules are followed as in the C<save()> method for choosing
 a serialization backend.
 
+The serialized structure will include a C<x_serialization_backend> entry giving
+the package and version used to serialize.  Any existing key in the given
+C<$meta> object will be clobbered.
+
 =cut
 
 sub as_string {
@@ -610,10 +614,14 @@ sub as_string {
   my ($data, $backend);
   if ( $version ge '2' ) {
     $backend = Parse::CPAN::Meta->json_backend();
+    local $struct->{x_serialization_backend} = sprintf '%s version %s',
+      $backend, $backend->VERSION;
     $data = $backend->new->pretty->canonical->encode($struct);
   }
   else {
     $backend = Parse::CPAN::Meta->yaml_backend();
+    local $struct->{x_serialization_backend} = sprintf '%s version %s',
+      $backend, $backend->VERSION;
     $data = eval { no strict 'refs'; &{"$backend\::Dump"}($struct) };
     if ( $@ ) {
       croak $backend->can('errstr') ? $backend->errstr : $@

--- a/t/save-load.t
+++ b/t/save-load.t
@@ -83,6 +83,16 @@ ok( -f $metafile, "save meta to file" );
 ok( my $loaded = Parse::CPAN::Meta->load_file($metafile), 'load saved file' );
 is($loaded->{name},     'Module-Build', 'name correct');
 
+like(
+  $loaded->{x_serialization_backend},
+  qr/\AJSON::PP version [0-9]/,
+  "x_serialization_backend",
+);
+
+ok(
+  ! exists $meta->{x_serialization_backend},
+  "we didn't leak x_serialization_backend up into the saved struct",
+);
 
 ok( $loaded = Parse::CPAN::Meta->load_file('t/data-test/META-1_4.yml'), 'load META-1.4' );
 is($loaded->{name},     'Module-Build', 'name correct');
@@ -97,6 +107,17 @@ ok( -f $metayml, "save meta to META.yml with conversion" );
 ok( $loaded = Parse::CPAN::Meta->load_file($metayml), 'load saved file' );
 is( $loaded->{name},     'Module-Build', 'name correct');
 is( $loaded->{requires}{perl}, "5.006", 'prereq correct' );
+
+like(
+  $loaded->{x_serialization_backend},
+  qr/\ACPAN::Meta::YAML version [0-9]/,
+  "x_serialization_backend",
+);
+
+ok(
+  ! exists $meta->{x_serialization_backend},
+  "we didn't leak x_serialization_backend up into the saved struct",
+);
 
 # file without suffix
 


### PR DESCRIPTION
I uncovered a bunch of weird JSON serialization errors in released
CPAN distributions, but I can't tell which JSON backend caused it.
Adding this will let us start to see what backend might have been
behind any future errors.