### PR TITLE
Add explicit license information to the historical META.yml specs

### DIFF
--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -7,7 +7,8 @@ CPAN::Meta::History::Meta_1_0 - Version 1.0 metadata specification for META.yml
 =head1 PREFACE
 
 This is a historical copy of the version 1.0 specification for F<META.yml>
-files, copyright by Ken Williams.
+files, copyright by Ken Williams and licensed under the same terms as Perl
+itself.
 
 Modifications from the original:
 

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -7,7 +7,8 @@ CPAN::Meta::History::Meta_1_1 - Version 1.1 metadata specification for META.yml
 =head1 PREFACE
 
 This is a historical copy of the version 1.1 specification for F<META.yml>
-files, copyright by Ken Williams.
+files, copyright by Ken Williams and licensed under the same terms as Perl
+itself.
 
 Modifications from the original:
 

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -7,7 +7,8 @@ CPAN::Meta::History::Meta_1_2 - Version 1.2 metadata specification for META.yml
 =head1 PREFACE
 
 This is a historical copy of the version 1.2 specification for F<META.yml>
-files, copyright by Ken Williams.
+files, copyright by Ken Williams and licensed under the same terms as Perl
+itself.
 
 Modifications from the original:
 

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -7,7 +7,8 @@ CPAN::Meta::History::Meta_1_3 - Version 1.3 metadata specification for META.yml
 =head1 PREFACE
 
 This is a historical copy of the version 1.3 specification for F<META.yml>
-files, copyright by Ken Williams.
+files, copyright by Ken Williams and licensed under the same terms as Perl
+itself.
 
 Modifications from the original:
 

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -7,7 +7,8 @@ CPAN::Meta::History::Meta_1_4 - Version 1.4 metadata specification for META.yml
 =head1 PREFACE
 
 This is a historical copy of the version 1.4 specification for F<META.yml>
-files, copyright by Ken Williams.
+files, copyright by Ken Williams and licensed under the same terms as Perl
+itself.
 
 Modifications from the original:
 


### PR DESCRIPTION
As the copyright of these files differs from the rest of the CPAN-Meta
distribution, it's not clear if the license of the distribution applies
to them. Add an explicit license grant to fix this.

The license grant is based on Ken's message at
 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=783201#15

Bug-Debian: https://bugs.debian.org/783201