### PR TITLE
add support for mixing and matching meta-spec version and serialization format

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ Revision history for CPAN-Meta
 
 {{$NEXT}}
 
+  [ADDED]
+
+  - Added ability for CPAN::Meta::as_string to mix and match meta spec
+    versions and serialization formats (e.g. JSON and version 1.4, YAML and
+    version 2)
+
   [DOCUMENTED]
 
   - Noted explicitly that historical META spec files are licensed under

--- a/lib/CPAN/Meta.pm
+++ b/lib/CPAN/Meta.pm
@@ -586,8 +586,10 @@ example:
 
   my $string = $meta->as_string( {version => "1.4"} );
 
-For C<version> greater than or equal to 2, the string will be serialized as
-JSON.  For C<version> less than 2, the string will be serialized as YAML.  In
+If the hashref contains a C<format> argument, that data format is used: valid
+choices are C<JSON> and C<YAML>. If C<format> is not provided,
+for C<version> greater than or equal to 2, the string will be serialized as
+JSON, and for C<version> less than 2, the string will be serialized as YAML.  In
 both cases, the same rules are followed as in the C<save()> method for choosing
 a serialization backend.
 
@@ -601,6 +603,8 @@ sub as_string {
   my ($self, $options) = @_;
 
   my $version = $options->{version} || '2';
+  my $format = $options->{format};
+  croak "unrecognized format: $format" if $format and $format ne 'JSON' and $format ne 'YAML';
 
   my $struct;
   if ( $self->meta_spec_version ne $version ) {
@@ -612,7 +616,7 @@ sub as_string {
   }
 
   my ($data, $backend);
-  if ( $version ge '2' ) {
+  if ( (not $format and $version ge '2') or ($format and $format eq 'JSON') ) {
     $backend = Parse::CPAN::Meta->json_backend();
     local $struct->{x_serialization_backend} = sprintf '%s version %s',
       $backend, $backend->VERSION;

--- a/t/data-valid/META-1.4.json
+++ b/t/data-valid/META-1.4.json
@@ -1,0 +1,61 @@
+{
+   "X_deep" : {
+      "deep" : "structure"
+   },
+   "abstract" : "Build and install Perl modules",
+   "author" : [
+      "Ken Williams <kwilliams@cpan.org>",
+      "Module-Build List <module-build@perl.org>"
+   ],
+   "build_requires" : {
+      "Test::More" : "0"
+   },
+   "dynamic_config" : 1,
+   "generated_by" : "Module::Build version 0.36, CPAN::Meta::Converter version __VERSION__",
+   "keywords" : [
+      "toolchain",
+      "cpan",
+      "dual-life"
+   ],
+   "license" : "perl",
+   "meta-spec" : {
+      "url" : "http://module-build.sourceforge.net/META-spec-v1.4.html",
+      "version" : "1.4"
+   },
+   "name" : "Module-Build",
+   "optional_features" : {
+      "domination" : {
+         "description" : "Take over the world",
+         "requires" : {
+            "Machine::Weather" : "2.0"
+         }
+      }
+   },
+   "recommends" : {
+      "Archive::Tar" : "1.00",
+      "ExtUtils::Install" : "0.3",
+      "ExtUtils::ParseXS" : "2.02",
+      "Pod::Text" : "0",
+      "YAML" : "0.35"
+   },
+   "requires" : {
+      "Config" : "0",
+      "Cwd" : "0",
+      "Data::Dumper" : "0",
+      "ExtUtils::Install" : "0",
+      "File::Basename" : "0",
+      "File::Compare" : "0",
+      "File::Copy" : "0",
+      "File::Find" : "0",
+      "File::Path" : "0",
+      "File::Spec" : "0",
+      "IO::File" : "0",
+      "perl" : "5.006"
+   },
+   "resources" : {
+      "license" : "http://dev.perl.org/licenses/"
+   },
+   "version" : "0.36",
+   "x_authority" : "cpan:FLORA",
+   "x_serialization_backend" : "__SERIALIZATION_BACKEND__"
+}

--- a/t/data-valid/META-1.4.yml
+++ b/t/data-valid/META-1.4.yml
@@ -1,0 +1,49 @@
+---
+X_deep:
+  deep: structure
+abstract: 'Build and install Perl modules'
+author:
+  - 'Ken Williams <kwilliams@cpan.org>'
+  - 'Module-Build List <module-build@perl.org>'
+build_requires:
+  Test::More: '0'
+dynamic_config: 1
+generated_by: 'Module::Build version 0.36, CPAN::Meta::Converter version $VERSION'
+keywords:
+  - toolchain
+  - cpan
+  - dual-life
+license: perl
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: '1.4'
+name: Module-Build
+optional_features:
+  domination:
+    description: 'Take over the world'
+    requires:
+      Machine::Weather: '2.0'
+recommends:
+  Archive::Tar: '1.00'
+  ExtUtils::Install: '0.3'
+  ExtUtils::ParseXS: '2.02'
+  Pod::Text: '0'
+  YAML: '0.35'
+requires:
+  Config: '0'
+  Cwd: '0'
+  Data::Dumper: '0'
+  ExtUtils::Install: '0'
+  File::Basename: '0'
+  File::Compare: '0'
+  File::Copy: '0'
+  File::Find: '0'
+  File::Path: '0'
+  File::Spec: '0'
+  IO::File: '0'
+  perl: '5.006'
+resources:
+  license: http://dev.perl.org/licenses/
+version: '0.36'
+x_authority: cpan:FLORA
+x_serialization_backend: 'CPAN::Meta::YAML version 0.015'

--- a/t/data-valid/META-1.4.yml
+++ b/t/data-valid/META-1.4.yml
@@ -8,7 +8,7 @@ author:
 build_requires:
   Test::More: '0'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.36, CPAN::Meta::Converter version $VERSION'
+generated_by: 'Module::Build version 0.36, CPAN::Meta::Converter version __VERSION__'
 keywords:
   - toolchain
   - cpan
@@ -46,4 +46,4 @@ resources:
   license: http://dev.perl.org/licenses/
 version: '0.36'
 x_authority: cpan:FLORA
-x_serialization_backend: 'CPAN::Meta::YAML version 0.015'
+x_serialization_backend: '__SERIALIZATION_BACKEND__'

--- a/t/data-valid/META-2.json
+++ b/t/data-valid/META-2.json
@@ -1,0 +1,82 @@
+{
+   "X_deep" : {
+      "deep" : "structure"
+   },
+   "abstract" : "Build and install Perl modules",
+   "author" : [
+      "Ken Williams <kwilliams@cpan.org>",
+      "Module-Build List <module-build@perl.org>"
+   ],
+   "description" : "Module::Build is a system for building, testing, and installing Perl modules.  It is meant to be an alternative to ExtUtils::MakeMaker... blah blah blah",
+   "dynamic_config" : 1,
+   "generated_by" : "Module::Build version 0.36",
+   "keywords" : [
+      "toolchain",
+      "cpan",
+      "dual-life"
+   ],
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "Module-Build",
+   "optional_features" : {
+      "domination" : {
+         "description" : "Take over the world",
+         "prereqs" : {
+            "develop" : {
+               "requires" : {
+                  "Genius::Evil" : "1.234"
+               }
+            },
+            "runtime" : {
+               "requires" : {
+                  "Machine::Weather" : "2.0"
+               }
+            }
+         }
+      }
+   },
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "Test::More" : "0"
+         }
+      },
+      "runtime" : {
+         "recommends" : {
+            "Archive::Tar" : "1.00",
+            "ExtUtils::Install" : "0.3",
+            "ExtUtils::ParseXS" : "2.02",
+            "Pod::Text" : "0",
+            "YAML" : "0.35"
+         },
+         "requires" : {
+            "Config" : "0",
+            "Cwd" : "0",
+            "Data::Dumper" : "0",
+            "ExtUtils::Install" : "0",
+            "File::Basename" : "0",
+            "File::Compare" : "0",
+            "File::Copy" : "0",
+            "File::Find" : "0",
+            "File::Path" : "0",
+            "File::Spec" : "0",
+            "IO::File" : "0",
+            "perl" : "5.006"
+         }
+      }
+   },
+   "release_status" : "stable",
+   "resources" : {
+      "license" : [
+         "http://dev.perl.org/licenses/"
+      ]
+   },
+   "version" : "0.36",
+   "x_authority" : "cpan:FLORA",
+   "x_serialization_backend" : "JSON::PP version 2.27300"
+}

--- a/t/data-valid/META-2.json
+++ b/t/data-valid/META-2.json
@@ -78,5 +78,5 @@
    },
    "version" : "0.36",
    "x_authority" : "cpan:FLORA",
-   "x_serialization_backend" : "JSON::PP version 2.27300"
+   "x_serialization_backend" : "__SERIALIZATION_BACKEND__"
 }

--- a/t/data-valid/META-2.yml
+++ b/t/data-valid/META-2.yml
@@ -1,0 +1,61 @@
+---
+X_deep:
+  deep: structure
+abstract: 'Build and install Perl modules'
+author:
+  - 'Ken Williams <kwilliams@cpan.org>'
+  - 'Module-Build List <module-build@perl.org>'
+description: 'Module::Build is a system for building, testing, and installing Perl modules.  It is meant to be an alternative to ExtUtils::MakeMaker... blah blah blah'
+dynamic_config: 1
+generated_by: 'Module::Build version 0.36'
+keywords:
+  - toolchain
+  - cpan
+  - dual-life
+license:
+  - perl_5
+meta-spec:
+  url: http://search.cpan.org/perldoc?CPAN::Meta::Spec
+  version: '2'
+name: Module-Build
+optional_features:
+  domination:
+    description: 'Take over the world'
+    prereqs:
+      develop:
+        requires:
+          Genius::Evil: '1.234'
+      runtime:
+        requires:
+          Machine::Weather: '2.0'
+prereqs:
+  build:
+    requires:
+      Test::More: '0'
+  runtime:
+    recommends:
+      Archive::Tar: '1.00'
+      ExtUtils::Install: '0.3'
+      ExtUtils::ParseXS: '2.02'
+      Pod::Text: '0'
+      YAML: '0.35'
+    requires:
+      Config: '0'
+      Cwd: '0'
+      Data::Dumper: '0'
+      ExtUtils::Install: '0'
+      File::Basename: '0'
+      File::Compare: '0'
+      File::Copy: '0'
+      File::Find: '0'
+      File::Path: '0'
+      File::Spec: '0'
+      IO::File: '0'
+      perl: '5.006'
+release_status: stable
+resources:
+  license:
+    - http://dev.perl.org/licenses/
+version: '0.36'
+x_authority: cpan:FLORA
+x_serialization_backend: '__SERIALIZATION_BACKEND__'

--- a/t/meta-obj.t
+++ b/t/meta-obj.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More 0.88;
 
 use CPAN::Meta;
-
+use Storable qw(dclone);
 use Scalar::Util qw(blessed);
 
 delete $ENV{$_} for qw/PERL_JSON_BACKEND PERL_YAML_BACKEND/; # use defaults
@@ -74,7 +74,7 @@ my $distmeta = {
   X_deep => { deep => 'structure' },
 };
 
-my $meta = CPAN::Meta->new($distmeta);
+my $meta = CPAN::Meta->new(dclone $distmeta);
 
 is(
   blessed($meta->as_struct),

--- a/t/meta-obj.t
+++ b/t/meta-obj.t
@@ -239,5 +239,33 @@ $chk_feature->($features[0]);
 
 $chk_feature->( $meta->feature('domination') );
 
+
+sub read_file {
+  my $filename = shift;
+  open my $fh, '<', $filename;
+  local $/;
+  my $string = <$fh>;
+  $string =~ s/\$VERSION/$CPAN::Meta::VERSION/g;
+  $string;
+}
+
+is(
+  $meta->as_string(),
+  read_file('t/data-valid/META-2.json'),
+  'as_string with no arguments defaults to version 2 and JSON',
+);
+
+is(
+  $meta->as_string({ version => 2 }),
+  read_file('t/data-valid/META-2.json'),
+  'as_string using version 2 defaults to JSON',
+);
+
+is(
+  $meta->as_string({ version => 1.4 }),
+  read_file('t/data-valid/META-1.4.yml'),
+  'as_string using version 1.4 defaults to YAML',
+);
+
 done_testing;
 # vim: ts=2 sts=2 sw=2 et :


### PR DESCRIPTION
This can be immediately used in Dist::Zilla::Plugin::MetaJSON, MetaYAML to remove the local serialization code, greatly simplifying its implementation.

I would suggest doing a stable release before merging this, so it can be released as its own trial without holding up the other changes that have already been released as a trial.