### PR TITLE
Historic specs cleanups

### DIFF
--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -51,13 +51,14 @@ reasons we chose YAML instead of, say, XML or Data::Dumper are discussed in
 L<this thread|http://www.nntp.perl.org/group/perl.makemaker/2002/04/msg406.html>
 on the MakeMaker mailing list.
 
-The first line of a F<META.yml> file should be a valid L<YAML document header|http://www.yaml.org/spec/#.Document>
+The first line of a F<META.yml> file should be a valid
+L<YAML document header|http://yaml.org/spec/history/2002-10-31.html#syntax-document>
 like C<"--- #YAML:1.0">
 
 =head1 Fields
 
 The rest of the META.yml file is one big YAML
-L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->,
+L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>,
 whose keys are described here.
 
 =over 4
@@ -149,7 +150,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules this distribution requires for proper
 operation.  The keys are the module names, and the values are version
 specifications as described in the
@@ -167,7 +168,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules this distribution recommends for enhanced
 operation.
 
@@ -178,7 +179,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules required for building and/or testing of
 this distribution.  These dependencies are not required after the
 module is installed.
@@ -190,7 +191,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules that cannot be installed while this
 distribution is installed.  This is a pretty uncommon situation.
 

--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -98,12 +98,12 @@ version 1 or the Artistic version 1 license.
 
 =item gpl
 
-The distribution is distributed under the terms of the Gnu General Public
+The distribution is distributed under the terms of the GNU General Public
 License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
-The distribution is distributed under the terms of the Gnu Lesser General
+The distribution is distributed under the terms of the GNU Lesser General
 Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item artistic

--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -148,7 +148,8 @@ Example:
 A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
 indicating the Perl modules this distribution requires for proper
 operation.  The keys are the module names, and the values are version
-specifications as described in the L<Module::Build|documentation for Module::Build's "requires" parameter>.
+specifications as described in the
+L<documentation for Module::Build's "requires" parameter|Module::Build::API/requires>.
 
 I<Note: the exact nature of the fancy specifications like
 C<< ">= 1.2, != 1.5, < 2.0" >> is subject to
@@ -202,7 +203,7 @@ sensing the environment, etc.) as part of its build/install process.
 
 Currently L<Module::Build> doesn't actually do anything with
 this flag - it's probably going to be up to higher-level tools like
-L<CPAN|CPAN.pm> to do something useful with it.  It can potentially
+L<CPAN.pm|CPAN> to do something useful with it.  It can potentially
 bring lots of security, packaging, and convenience improvements.
 
 =item generated_by

--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -21,7 +21,8 @@ Conversion from the original HTML to POD format
 =item *
 
 Include list of valid licenses from L<Module::Build> 0.17 rather than
-linking to the module.
+linking to the module, with minor updates to text and links to reflect
+versions at the time of publication.
 
 =back
 
@@ -87,28 +88,29 @@ Must be one of the following licenses:
 
 The distribution may be copied and redistributed under the same terms as perl
 itself (this is by far the most common licensing option for modules on CPAN).
-This is a dual license, in which the user may choose between either the GPL or
-the Artistic license.
+This is a dual license, in which the user may choose between either the GPL
+version 1 or the Artistic version 1 license.
 
 =item gpl
 
 The distribution is distributed under the terms of the Gnu General Public
-License (L<http://www.opensource.org/licenses/gpl-license.php>).
+License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
 The distribution is distributed under the terms of the Gnu Lesser General
-Public License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item artistic
 
-The distribution is licensed under the Artistic License, as specified by the
-Artistic file in the standard perl distribution.
+The distribution is licensed under the Artistic License version 1, as specified
+by the Artistic file in the standard perl distribution
+(L<http://opensource.org/licenses/Artistic-Perl-1.0>).
 
 =item bsd
 
-The distribution is licensed under the BSD License
-(L<http://www.opensource.org/licenses/bsd-license.php>).
+The distribution is licensed under the BSD 3-Clause License
+(L<http://opensource.org/licenses/BSD-3-Clause>).
 
 =item open_source
 
@@ -118,7 +120,7 @@ license listed at L<http://www.opensource.org/licenses/>.
 =item unrestricted
 
 The distribution is licensed under a license that is B<not> approved by
-L<www.opensource.org|http://www.opensource.org> but that allows distribution
+L<www.opensource.org|http://www.opensource.org/> but that allows distribution
 without restrictions.
 
 =item restrictive

--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -44,7 +44,7 @@ install it.
 
 F<META.yml> files are written in the L<YAML|http://www.yaml.org/> format.  The
 reasons we chose YAML instead of, say, XML or Data::Dumper are discussed in
-L<this thread|http://archive.develooper.com/makemaker@perl.org/msg00405.html>
+L<this thread|http://www.nntp.perl.org/group/perl.makemaker/2002/04/msg406.html>
 on the MakeMaker mailing list.
 
 The first line of a F<META.yml> file should be a valid L<YAML document header|http://www.yaml.org/spec/#.Document>

--- a/lib/CPAN/Meta/History/Meta_1_0.pod
+++ b/lib/CPAN/Meta/History/Meta_1_0.pod
@@ -24,6 +24,10 @@ Include list of valid licenses from L<Module::Build> 0.17 rather than
 linking to the module, with minor updates to text and links to reflect
 versions at the time of publication.
 
+=item *
+
+Fixed some dead links to point to active resources.
+
 =back
 
 =head1 DESCRIPTION

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -113,12 +113,12 @@ version 1 or the Artistic version 1 license.
 
 =item gpl
 
-The distribution is distributed under the terms of the Gnu General Public
+The distribution is distributed under the terms of the GNU General Public
 License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
-The distribution is distributed under the terms of the Gnu Lesser General
+The distribution is distributed under the terms of the GNU Lesser General
 Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item artistic

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -51,13 +51,14 @@ reasons we chose YAML instead of, say, XML or Data::Dumper are discussed in
 L<this thread|http://www.nntp.perl.org/group/perl.makemaker/2002/04/msg406.html>
 on the MakeMaker mailing list.
 
-The first line of a F<META.yml> file should be a valid L<YAML document header|http://www.yaml.org/spec/#.Document>
+The first line of a F<META.yml> file should be a valid
+L<YAML document header|http://yaml.org/spec/history/2002-10-31.html#syntax-document>
 like C<"--- #YAML:1.0">
 
 =head1 Fields
 
 The rest of the META.yml file is one big YAML
-L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->,
+L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>,
 whose keys are described here.
 
 =over 4
@@ -181,7 +182,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules this distribution requires for proper
 operation.  The keys are the module names, and the values are version
 specifications as described in the
@@ -199,7 +200,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules this distribution recommends for enhanced
 operation.
 
@@ -210,7 +211,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules required for building and/or testing of
 this distribution.  These dependencies are not required after the
 module is installed.
@@ -222,7 +223,7 @@ Example:
   Data::Dumper: 0
   File::Find: 1.03
 
-A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
+A YAML L<mapping|http://yaml.org/spec/history/2002-10-31.html#syntax-mapping>
 indicating the Perl modules that cannot be installed while this
 distribution is installed.  This is a pretty uncommon situation.
 

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -24,6 +24,10 @@ Include list of valid licenses from L<Module::Build> 0.18 rather than
 linking to the module, with minor updates to text and links to reflect
 versions at the time of publication.
 
+=item *
+
+Fixed some dead links to point to active resources.
+
 =back
 
 =head1 DESCRIPTION

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -21,7 +21,8 @@ Conversion from the original HTML to POD format
 =item *
 
 Include list of valid licenses from L<Module::Build> 0.18 rather than
-linking to the module.
+linking to the module, with minor updates to text and links to reflect
+versions at the time of publication.
 
 =back
 
@@ -102,28 +103,29 @@ Must be one of the following licenses:
 
 The distribution may be copied and redistributed under the same terms as perl
 itself (this is by far the most common licensing option for modules on CPAN).
-This is a dual license, in which the user may choose between either the GPL or
-the Artistic license.
+This is a dual license, in which the user may choose between either the GPL
+version 1 or the Artistic version 1 license.
 
 =item gpl
 
 The distribution is distributed under the terms of the Gnu General Public
-License (L<http://www.opensource.org/licenses/gpl-license.php>).
+License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
 The distribution is distributed under the terms of the Gnu Lesser General
-Public License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item artistic
 
-The distribution is licensed under the Artistic License, as specified by the
-Artistic file in the standard perl distribution.
+The distribution is licensed under the Artistic License version 1, as specified
+by the Artistic file in the standard perl distribution
+(L<http://opensource.org/licenses/Artistic-Perl-1.0>).
 
 =item bsd
 
-The distribution is licensed under the BSD License
-(L<http://www.opensource.org/licenses/bsd-license.php>).
+The distribution is licensed under the BSD 3-Clause License
+(L<http://opensource.org/licenses/BSD-3-Clause>).
 
 =item open_source
 
@@ -133,7 +135,7 @@ license listed at L<http://www.opensource.org/licenses/>.
 =item unrestricted
 
 The distribution is licensed under a license that is B<not> approved by
-L<www.opensource.org|http://www.opensource.org> but that allows distribution
+L<www.opensource.org|http://www.opensource.org/> but that allows distribution
 without restrictions.
 
 =item restrictive

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -180,7 +180,8 @@ Example:
 A YAML L<mapping|http://www.yaml.org/spec/#.-syntax-mapping-Mapping->
 indicating the Perl modules this distribution requires for proper
 operation.  The keys are the module names, and the values are version
-specifications as described in the L<Module::Build|documentation for Module::Build's "requires" parameter>.
+specifications as described in the
+L<documentation for Module::Build's "requires" parameter|Module::Build::API/requires>.
 
 I<Note: the exact nature of the fancy specifications like
 C<< ">= 1.2, != 1.5, < 2.0" >> is subject to
@@ -241,7 +242,7 @@ sensing the environment, etc.) as part of its build/install process.
 
 Currently L<Module::Build> doesn't actually do anything with
 this flag - it's probably going to be up to higher-level tools like
-L<CPAN|CPAN.pm> to do something useful with it.  It can potentially
+L<CPAN.pm|CPAN> to do something useful with it.  It can potentially
 bring lots of security, packaging, and convenience improvements.
 
 =item generated_by

--- a/lib/CPAN/Meta/History/Meta_1_1.pod
+++ b/lib/CPAN/Meta/History/Meta_1_1.pod
@@ -44,7 +44,7 @@ install it.
 
 F<META.yml> files are written in the L<YAML|http://www.yaml.org/> format.  The
 reasons we chose YAML instead of, say, XML or Data::Dumper are discussed in
-L<this thread|http://archive.develooper.com/makemaker@perl.org/msg00405.html>
+L<this thread|http://www.nntp.perl.org/group/perl.makemaker/2002/04/msg406.html>
 on the MakeMaker mailing list.
 
 The first line of a F<META.yml> file should be a valid L<YAML document header|http://www.yaml.org/spec/#.Document>

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -131,8 +131,8 @@ well (ex. python, ruby).
 
 =head1 VERSION SPECIFICATIONS
 
-Some fields require a version specification (ex. L<"requires">,
-L<"recommends">, L<"build_requires">, etc.).  This section details the
+Some fields require a version specification (ex. L</requires>,
+L</recommends>, L</build_requires>, etc.).  This section details the
 version specifications that are currently supported.
 
 If a single version is listed, then that version is considered to be
@@ -337,9 +337,9 @@ Example:
 
 I<(Spec 1.1) [optional] {map} A YAML sequence of names for optional features
 which are made available when its requirements are met. For each
-feature a description is provided along with any of L<"requires">,
-L<"build_requires">, L<"conflicts">, L<"requires_packages">,
-L<"requires_os">, and L<"excludes_os"> which have the same meaning in
+feature a description is provided along with any of L</requires>,
+L</build_requires>, L</conflicts>, C<requires_packages>,
+C<requires_os>, and C<excludes_os> which have the same meaning in
 this subcontext as described elsewhere in this document.>
 
 =head2 build_requires
@@ -390,7 +390,7 @@ If this field is omitted, it defaults to 1 (true).
 =head2 private
 
 I<(Deprecated)> (Spec 1.0) [optional] {map} This field has been renamed to
-L</"no_index">.  See below.
+L</no_index>.  See below.
 
 =head2 provides
 
@@ -570,7 +570,7 @@ Created version 1.0 of this document.
 
 =item *
 
-Added the L</"dynamic_config"> field, which was missing from the initial
+Added the L</dynamic_config> field, which was missing from the initial
 version.
 
 =back
@@ -590,12 +590,12 @@ L<http://nntp.x.perl.org/group/> site.
 
 =item *
 
-Added and deprecated the L<"private"> field.
+Added and deprecated the L</private> field.
 
 =item *
 
-Added L<"abstract">, L<"configure">, L<"requires_packages">,
-L<"requires_os">, L<"excludes_os">, and L<"no_index"> fields.
+Added L</abstract>, C<configure>, C<requires_packages>,
+C<requires_os>, C<excludes_os>, and L</no_index> fields.
 
 =item *
 
@@ -609,15 +609,15 @@ Bumped version.
 
 =item *
 
-Added L<"generation">, L<"authored_by"> fields.
+Added C<generation>, C<authored_by> fields.
 
 =item *
 
-Add alternative proposal to the L<"recommends"> field.
+Add alternative proposal to the L</recommends> field.
 
 =item *
 
-Add proposal for a L<"requires_build_tools"> field.
+Add proposal for a C<requires_build_tools> field.
 
 =back
 
@@ -631,7 +631,7 @@ Added link to latest version of this specification on CPAN.
 
 =item *
 
-Added section L<"VERSION SPECIFICATIONS">.
+Added section L</"VERSION SPECIFICATIONS">.
 
 =item *
 
@@ -639,7 +639,7 @@ Chang name from Module::Build::META-spec to CPAN::META::Specification.
 
 =item *
 
-Add proposal for L<"auto_regenerate"> field.
+Add proposal for C<auto_regenerate> field.
 
 =back
 
@@ -649,15 +649,15 @@ Add proposal for L<"auto_regenerate"> field.
 
 =item *
 
-Add L<"index"> field as a compliment to L<"no_index">
+Add C<index> field as a compliment to L</no_index>
 
 =item *
 
-Add L<"keywords"> field as a means to aid searching distributions.
+Add L</keywords> field as a means to aid searching distributions.
 
 =item *
 
-Add L<"TERMINOLOGY"> section to explain certain terms that may be
+Add L</TERMINOLOGY> section to explain certain terms that may be
 ambiguous.
 
 =back
@@ -675,7 +675,7 @@ more like records of brainstorming.
 
 =item *
 
-Changed C<authored_by> to C<author>, since that's always been what
+Changed C<authored_by> to L</author>, since that's always been what
 it's actually called in actual F<META.yml> files.
 
 =item *
@@ -685,12 +685,12 @@ operators.
 
 =item *
 
-Noted that the C<distribution_type> field is basically meaningless,
+Noted that the L</distribution_type> field is basically meaningless,
 and shouldn't really be used.
 
 =item *
 
-Clarified C<dynamic_config> a bit.
+Clarified L</dynamic_config> a bit.
 
 =back
 

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -246,12 +246,12 @@ version 1 or the Artistic version 1 license.
 
 =item gpl
 
-The distribution is distributed under the terms of the Gnu General Public
+The distribution is distributed under the terms of the GNU General Public
 License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
-The distribution is distributed under the terms of the Gnu Lesser General
+The distribution is distributed under the terms of the GNU Lesser General
 Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item artistic

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -97,21 +97,15 @@ XML or Data::Dumper:
 
 =item *
 
-Module::Build design plans
-
-L<http://nntp.x.perl.org/group/perl.makemaker/406>
+L<Module::Build design plans|http://www.nntp.perl.org/group/perl.makemaker/2002/04/msg407.html>
 
 =item *
 
-Not keen on YAML
-
-L<http://nntp.x.perl.org/group/perl.module-authors/1353>
+L<Not keen on YAML|http://www.nntp.perl.org/group/perl.module-authors/2003/11/msg1353.html>
 
 =item *
 
-META Concerns
-
-L<http://nntp.x.perl.org/group/perl.module-authors/1385>
+L<META Concerns|http://www.nntp.perl.org/group/perl.module-authors/2003/11/msg1385.html>
 
 =back
 

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -24,6 +24,10 @@ Include list of valid licenses from L<Module::Build> 0.2611 rather than
 linking to the module, with minor updates to text and links to reflect
 versions at the time of publication.
 
+=item *
+
+Fixed some dead links to point to active resources.
+
 =back
 
 =head1 SYNOPSIS

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -412,7 +412,7 @@ cases, is) used by distribution and automation mechanisms like PAUSE,
 CPAN, and search.cpan.org to build indexes saying in which
 distribution various packages can be found.
 
-When using tools like C<Module::Build> that can generate the
+When using tools like L<Module::Build> that can generate the
 C<provides> mapping for your distribution automatically, make sure you
 examine what it generates to make sure it makes sense - indexers will
 usually trust the C<provides> field if it's present, rather than
@@ -532,23 +532,23 @@ tool. RWS]
 
 =head1 SEE ALSO
 
-CPAN, L<http://www.cpan.org/>
+L<CPAN|http://www.cpan.org/>
 
-CPAN.pm, L<http://search.cpan.org/author/ANDK/CPAN/>
+L<CPAN.pm|CPAN>
 
-CPANPLUS, L<http://search.cpan.org/author/KANE/CPANPLUS/>
+L<CPANPLUS>
 
-Data::Dumper, L<http://search.cpan.org/author/ILYAM/Data-Dumper/>
+L<Data::Dumper>
 
-ExtUtils::MakeMaker, L<http://search.cpan.org/author/MSCHWERN/ExtUtils-MakeMaker/>
+L<ExtUtils::MakeMaker>
 
-Module::Build, L<http://search.cpan.org/author/KWILLIAMS/Module-Build/>
+L<Module::Build>
 
-Module::Install, L<http://search.cpan.org/author/KWILLIAMS/Module-Install/>
+L<Module::Install>
 
-XML, L<http://www.w3.org/XML/>
+L<XML|http://www.w3.org/XML/>
 
-YAML, L<http://www.yaml.org/>
+L<YAML|http://www.yaml.org/>
 
 =head1 HISTORY
 

--- a/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -21,7 +21,8 @@ Various spelling corrections
 =item *
 
 Include list of valid licenses from L<Module::Build> 0.2611 rather than
-linking to the module.
+linking to the module, with minor updates to text and links to reflect
+versions at the time of publication.
 
 =back
 
@@ -242,28 +243,29 @@ Must be one of the following licenses:
 
 The distribution may be copied and redistributed under the same terms as perl
 itself (this is by far the most common licensing option for modules on CPAN).
-This is a dual license, in which the user may choose between either the GPL or
-the Artistic license.
+This is a dual license, in which the user may choose between either the GPL
+version 1 or the Artistic version 1 license.
 
 =item gpl
 
 The distribution is distributed under the terms of the Gnu General Public
-License (L<http://www.opensource.org/licenses/gpl-license.php>).
+License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
 The distribution is distributed under the terms of the Gnu Lesser General
-Public License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item artistic
 
-The distribution is licensed under the Artistic License, as specified by the
-Artistic file in the standard perl distribution.
+The distribution is licensed under the Artistic License version 1, as specified
+by the Artistic file in the standard perl distribution
+(L<http://opensource.org/licenses/Artistic-Perl-1.0>).
 
 =item bsd
 
-The distribution is licensed under the BSD License
-(L<http://www.opensource.org/licenses/bsd-license.php>).
+The distribution is licensed under the BSD 3-Clause License
+(L<http://opensource.org/licenses/BSD-3-Clause>).
 
 =item open_source
 
@@ -273,7 +275,7 @@ license listed at L<http://www.opensource.org/licenses/>.
 =item unrestricted
 
 The distribution is licensed under a license that is B<not> approved by
-L<www.opensource.org|http://www.opensource.org> but that allows distribution
+L<www.opensource.org|http://www.opensource.org/> but that allows distribution
 without restrictions.
 
 =item restrictive

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -24,6 +24,10 @@ Include list of valid licenses from L<Module::Build> 0.2805 rather than
 linking to the module, with minor updates to text and links to reflect
 versions at the time of publication.
 
+=item *
+
+Fixed some dead links to point to active resources.
+
 =back
 
 =head1 SYNOPSIS

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -95,17 +95,17 @@ XML or Data::Dumper:
 
 =over 4
 
-=item Module::Build design plans
+=item *
 
-L<http://nntp.x.perl.org/group/perl.makemaker/406>
+L<Module::Build design plans|http://www.nntp.perl.org/group/perl.makemaker/2002/04/msg407.html>
 
-=item Not keen on YAML
+=item *
 
-L<http://nntp.x.perl.org/group/perl.module-authors/1353>
+L<Not keen on YAML|http://www.nntp.perl.org/group/perl.module-authors/2003/11/msg1353.html>
 
-=item META Concerns
+=item *
 
-L<http://nntp.x.perl.org/group/perl.module-authors/1385>
+L<META Concerns|http://www.nntp.perl.org/group/perl.module-authors/2003/11/msg1385.html>
 
 =back
 

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -227,12 +227,12 @@ The distribution is licensed under the BSD 3-Clause License
 
 =item gpl
 
-The distribution is distributed under the terms of the Gnu General Public
+The distribution is distributed under the terms of the GNU General Public
 License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
-The distribution is distributed under the terms of the Gnu Lesser General
+The distribution is distributed under the terms of the GNU Lesser General
 Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item mit

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -409,7 +409,7 @@ cases, is) used by distribution and automation mechanisms like PAUSE,
 CPAN, and search.cpan.org to build indexes saying in which
 distribution various packages can be found.
 
-When using tools like C<Module::Build> that can generate the
+When using tools like L<Module::Build> that can generate the
 C<provides> mapping for your distribution automatically, make sure you
 examine what it generates to make sure it makes sense - indexers will
 usually trust the C<provides> field if it's present, rather than
@@ -439,7 +439,7 @@ directories, packages, and namespaces that are private
 and indexing tools.  This is useful when no C<provides> field is
 present.
 
-For example, C<search.cpan.org> excludes items listed in C<no_index>
+For example, L<http://search.cpan.org/> excludes items listed in C<no_index>
 when searching for POD, meaning files in these directories will not
 converted to HTML and made public - which is useful if you have
 example or test PODs that you don't want the search engine to go
@@ -561,23 +561,23 @@ together using commas.  The specification C<E<gt>= 1.2, != 1.5, E<lt>
 
 =head1 SEE ALSO
 
-CPAN, L<http://www.cpan.org/>
+L<CPAN|http://www.cpan.org/>
 
-CPAN.pm, L<http://search.cpan.org/dist/CPAN/>
+L<CPAN.pm|CPAN>
 
-CPANPLUS, L<http://search.cpan.org/dist/CPANPLUS/>
+L<CPANPLUS>
 
-Data::Dumper, L<http://search.cpan.org/dist/Data-Dumper/>
+L<Data::Dumper>
 
-ExtUtils::MakeMaker, L<http://search.cpan.org/dist/ExtUtils-MakeMaker/>
+L<ExtUtils::MakeMaker>
 
-Module::Build, L<http://search.cpan.org/dist/Module-Build/>
+L<Module::Build>
 
-Module::Install, L<http://search.cpan.org/dist/Module-Install/>
+L<Module::Install>
 
-XML, L<http://www.w3.org/XML/>
+L<XML|http://www.w3.org/XML/>
 
-YAML, L<http://www.yaml.org/>
+L<YAML|http://www.yaml.org/>
 
 =head1 HISTORY
 

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -21,7 +21,8 @@ Various spelling corrections
 =item *
 
 Include list of valid licenses from L<Module::Build> 0.2805 rather than
-linking to the module.
+linking to the module, with minor updates to text and links to reflect
+versions at the time of publication.
 
 =back
 
@@ -206,39 +207,40 @@ Must be one of the following licenses:
 
 =item apache
 
-The distribution is licensed under the Apache Software License
-(L<http://opensource.org/licenses/apachepl.php>).
+The distribution is licensed under the Apache Software License version 1.1
+(L<http://opensource.org/licenses/Apache-1.1>).
 
 =item artistic
 
-The distribution is licensed under the Artistic License, as specified by the
-Artistic file in the standard perl distribution.
+The distribution is licensed under the Artistic License version 1, as specified
+by the Artistic file in the standard perl distribution
+(L<http://opensource.org/licenses/Artistic-Perl-1.0>).
 
 =item bsd
 
-The distribution is licensed under the BSD License
-(L<http://www.opensource.org/licenses/bsd-license.php>).
+The distribution is licensed under the BSD 3-Clause License
+(L<http://opensource.org/licenses/BSD-3-Clause>).
 
 =item gpl
 
-The distribution is licensed under the terms of the Gnu General Public License
-(L<http://www.opensource.org/licenses/gpl-license.php>).
+The distribution is distributed under the terms of the Gnu General Public
+License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
-The distribution is licensed under the terms of the Gnu Lesser General Public
-License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+The distribution is distributed under the terms of the Gnu Lesser General
+Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item mit
 
 The distribution is licensed under the MIT License
-(L<http://opensource.org/licenses/mit-license.php>).
+(L<http://opensource.org/licenses/MIT>).
 
 =item mozilla
 
 The distribution is licensed under the Mozilla Public License.
-(L<http://opensource.org/licenses/mozilla1.0.php> or
-L<http://opensource.org/licenses/mozilla1.1.php>)
+(L<http://opensource.org/licenses/MPL-1.0> or
+L<http://opensource.org/licenses/MPL-1.1>)
 
 =item open_source
 
@@ -249,8 +251,8 @@ license listed at L<http://www.opensource.org/licenses/>.
 
 The distribution may be copied and redistributed under the same terms as perl
 itself (this is by far the most common licensing option for modules on CPAN).
-This is a dual license, in which the user may choose between either the GPL or
-the Artistic license.
+This is a dual license, in which the user may choose between either the GPL
+version 1 or the Artistic version 1 license.
 
 =item restrictive
 

--- a/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -294,7 +294,7 @@ Example:
 (Spec 1.0) [optional] {map} A YAML mapping indicating the Perl modules this
 distribution requires for proper operation.  The keys are the module
 names, and the values are version specifications as described in
-L<VERSION SPECIFICATIONS>.
+L</"VERSION SPECIFICATIONS">.
 
 =head2 recommends
 
@@ -307,7 +307,7 @@ Example:
 (Spec 1.0) [optional] {map} A YAML mapping indicating the Perl modules
 this distribution recommends for enhanced operation.  The keys are the
 module names, and the values are version specifications as described
-in L<VERSION SPECIFICATIONS>.
+in L</"VERSION SPECIFICATIONS">.
 
 
 
@@ -329,9 +329,9 @@ Example:
 
 I<(Spec 1.1) [optional] {map} A YAML sequence of names for optional features
 which are made available when its requirements are met. For each
-feature a description is provided along with any of L<"requires">,
-L<"build_requires">, L<"conflicts">, L<"requires_packages">,
-L<"requires_os">, and L<"excludes_os"> which have the same meaning in
+feature a description is provided along with any of L</requires>,
+L</build_requires>, L</conflicts>, C<requires_packages>,
+C<requires_os>, and C<excludes_os> which have the same meaning in
 this subcontext as described elsewhere in this document.>
 
 =head2 build_requires
@@ -345,7 +345,7 @@ Example:
 (Spec 1.0) [optional] {map} A YAML mapping indicating the Perl modules
 required for building and/or testing of this distribution.  The keys
 are the module names, and the values are version specifications as
-described in L<VERSION SPECIFICATIONS>.  These dependencies are not
+described in L</"VERSION SPECIFICATIONS">.  These dependencies are not
 required after the module is installed.
 
 =head2 conflicts
@@ -360,7 +360,7 @@ Example:
 cannot be installed while this distribution is installed.  This is a
 pretty uncommon situation.  The keys for C<conflicts> are the module
 names, and the values are version specifications as described in
-L<VERSION SPECIFICATIONS>.
+L</"VERSION SPECIFICATIONS">.
 
 
 =head2 dynamic_config
@@ -387,7 +387,7 @@ If this field is omitted, it defaults to 1 (true).
 =head2 private
 
 I<(Deprecated)> (Spec 1.0) [optional] {map} This field has been renamed to
-L</"no_index">.  See below.
+L</no_index>.  See below.
 
 =head2 provides
 
@@ -536,8 +536,8 @@ tool. RWS]
 
 =head1 VERSION SPECIFICATIONS
 
-Some fields require a version specification (ex. L<"requires">,
-L<"recommends">, L<"build_requires">, etc.) to indicate the particular
+Some fields require a version specification (ex. L</requires>,
+L</recommends>, L</build_requires>, etc.) to indicate the particular
 versionZ<>(s) of some other module that may be required as a
 prerequisite.  This section details the version specification formats
 that are currently supported.
@@ -599,7 +599,7 @@ Created version 1.0 of this document.
 
 =item *
 
-Added the L</"dynamic_config"> field, which was missing from the initial
+Added the L</dynamic_config> field, which was missing from the initial
 version.
 
 =back
@@ -619,12 +619,12 @@ L<http://nntp.x.perl.org/group/> site.
 
 =item *
 
-Added and deprecated the L<"private"> field.
+Added and deprecated the L</private> field.
 
 =item *
 
-Added L<"abstract">, L<"configure">, L<"requires_packages">,
-L<"requires_os">, L<"excludes_os">, and L<"no_index"> fields.
+Added L</abstract>, C<configure>, C<requires_packages>,
+C<requires_os>, C<excludes_os>, and L</no_index> fields.
 
 =item *
 
@@ -638,15 +638,15 @@ Bumped version.
 
 =item *
 
-Added L<"generation">, L<"authored_by"> fields.
+Added C<generation>, C<authored_by> fields.
 
 =item *
 
-Add alternative proposal to the L<"recommends"> field.
+Add alternative proposal to the L</recommends> field.
 
 =item *
 
-Add proposal for a L<"requires_build_tools"> field.
+Add proposal for a C<requires_build_tools> field.
 
 =back
 
@@ -660,7 +660,7 @@ Added link to latest version of this specification on CPAN.
 
 =item *
 
-Added section L<"VERSION SPECIFICATIONS">.
+Added section L</"VERSION SPECIFICATIONS">.
 
 =item *
 
@@ -668,7 +668,7 @@ Chang name from Module::Build::META-spec to CPAN::META::Specification.
 
 =item *
 
-Add proposal for L<"auto_regenerate"> field.
+Add proposal for C<auto_regenerate> field.
 
 =back
 
@@ -678,15 +678,15 @@ Add proposal for L<"auto_regenerate"> field.
 
 =item *
 
-Add L<"index"> field as a compliment to L<"no_index">
+Add C<index> field as a compliment to L</no_index>
 
 =item *
 
-Add L<"keywords"> field as a means to aid searching distributions.
+Add L</keywords> field as a means to aid searching distributions.
 
 =item *
 
-Add L<"TERMINOLOGY"> section to explain certain terms that may be
+Add L</TERMINOLOGY> section to explain certain terms that may be
 ambiguous.
 
 =back
@@ -704,7 +704,7 @@ more like records of brainstorming.
 
 =item *
 
-Changed C<authored_by> to C<author>, since that's always been what
+Changed C<authored_by> to L</author>, since that's always been what
 it's actually called in actual F<META.yml> files.
 
 =item *
@@ -714,12 +714,12 @@ operators.
 
 =item *
 
-Noted that the C<distribution_type> field is basically meaningless,
+Noted that the L</distribution_type> field is basically meaningless,
 and shouldn't really be used.
 
 =item *
 
-Clarified C<dynamic_config> a bit.
+Clarified L</dynamic_config> a bit.
 
 =back
 

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -85,35 +85,6 @@ and the latest development version (which may include things that
 won't make it into the stable version) can always be found at
 L<http://module-build.sourceforge.net/META-spec-blead.html>.>
 
-=begin MAINTAINER
-
-The master source for the META spec is META-spec.pod.  META-spec.html
-is built (manually) from META-spec.pod whenever there are changes, and
-the two files should generally be checked in together.  Ideally it
-would happen through a trigger or something, but it doesn't.
-
-Ken has a cron job that copies the latest bleeding-edge version of the
-spec (HTML version) to Sourceforge whenever his laptop is turned on:
-
-  21 * * * * svn cat http://svn.perl.org/modules/Module-Build/trunk/website/META-spec.html \
-       | ssh kwilliams@shell.sourceforge.net \
-       'cat > /home/groups/m/mo/module-build/htdocs/META-spec-blead.html'
-
-The numbered revisions of the spec at
-L<"http://module-build.sourceforge.net/"> are captures of the spec at
-opportune moments.  A couple of symlinks also exist for convenience:
-
- -rw-r--r--  1 kwilliams 24585 Oct 10 17:21 META-spec-blead.html
- lrwxrwxrwx  1 kwilliams    19 Jan 19  2007 META-spec-current.html -> META-spec-v1.3.html
- lrwxrwxrwx  1 kwilliams    22 Jan 19  2007 META-spec.html -> META-spec-current.html
- -rw-r--r--  1 kwilliams  5830 Jul 25  2005 META-spec-v1.0.html
- -rw-r--r--  1 kwilliams  7847 Jul 25  2005 META-spec-v1.1.html
- -rw-r--r--  1 kwilliams 22635 Aug 23  2005 META-spec-v1.2.html
- -rw-r--r--  1 kwilliams 24086 Nov  4  2006 META-spec-v1.3.html
-
-=end MAINTAINER
-
-
 =head1 FORMAT
 
 F<META.yml> files are written in the YAML format (see

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -124,17 +124,17 @@ XML or Data::Dumper:
 
 =over 4
 
-=item Module::Build design plans
+=item *
 
-L<http://nntp.x.perl.org/group/perl.makemaker/406>
+L<Module::Build design plans|http://www.nntp.perl.org/group/perl.makemaker/2002/04/msg407.html>
 
-=item Not keen on YAML
+=item *
 
-L<http://nntp.x.perl.org/group/perl.module-authors/1353>
+L<Not keen on YAML|http://www.nntp.perl.org/group/perl.module-authors/2003/11/msg1353.html>
 
-=item META Concerns
+=item *
 
-L<http://nntp.x.perl.org/group/perl.module-authors/1385>
+L<META Concerns|http://www.nntp.perl.org/group/perl.module-authors/2003/11/msg1385.html>
 
 =back
 

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -227,12 +227,12 @@ The distribution is licensed under the BSD 3-Clause License
 
 =item gpl
 
-The distribution is distributed under the terms of the Gnu General Public
+The distribution is distributed under the terms of the GNU General Public
 License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
-The distribution is distributed under the terms of the Gnu Lesser General
+The distribution is distributed under the terms of the GNU Lesser General
 Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item mit

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -21,7 +21,8 @@ Various spelling corrections
 =item *
 
 Include list of valid licenses from L<Module::Build> 0.2807 rather than
-linking to the module.
+linking to the module, with minor updates to text and links to reflect
+versions at the time of publication.
 
 =back
 
@@ -235,39 +236,40 @@ Must be one of the following licenses:
 
 =item apache
 
-The distribution is licensed under the Apache Software License
-(L<http://opensource.org/licenses/apachepl.php>).
+The distribution is licensed under the Apache Software License version 1.1
+(L<http://opensource.org/licenses/Apache-1.1>).
 
 =item artistic
 
-The distribution is licensed under the Artistic License, as specified by the
-Artistic file in the standard perl distribution.
+The distribution is licensed under the Artistic License version 1, as specified
+by the Artistic file in the standard perl distribution
+(L<http://opensource.org/licenses/Artistic-Perl-1.0>).
 
 =item bsd
 
-The distribution is licensed under the BSD License
-(L<http://www.opensource.org/licenses/bsd-license.php>).
+The distribution is licensed under the BSD 3-Clause License
+(L<http://opensource.org/licenses/BSD-3-Clause>).
 
 =item gpl
 
-The distribution is licensed under the terms of the Gnu General Public License
-(L<http://www.opensource.org/licenses/gpl-license.php>).
+The distribution is distributed under the terms of the Gnu General Public
+License version 2 (L<http://opensource.org/licenses/GPL-2.0>).
 
 =item lgpl
 
-The distribution is licensed under the terms of the Gnu Lesser General Public
-License (L<http://www.opensource.org/licenses/lgpl-license.php>).
+The distribution is distributed under the terms of the Gnu Lesser General
+Public License version 2 (L<http://opensource.org/licenses/LGPL-2.1>).
 
 =item mit
 
 The distribution is licensed under the MIT License
-(L<http://opensource.org/licenses/mit-license.php>).
+(L<http://opensource.org/licenses/MIT>).
 
 =item mozilla
 
 The distribution is licensed under the Mozilla Public License.
-(L<http://opensource.org/licenses/mozilla1.0.php> or
-L<http://opensource.org/licenses/mozilla1.1.php>)
+(L<http://opensource.org/licenses/MPL-1.0> or
+L<http://opensource.org/licenses/MPL-1.1>)
 
 =item open_source
 

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -452,7 +452,7 @@ cases, is) used by distribution and automation mechanisms like PAUSE,
 CPAN, and search.cpan.org to build indexes saying in which
 distribution various packages can be found.
 
-When using tools like C<Module::Build> that can generate the
+When using tools like L<Module::Build> that can generate the
 C<provides> mapping for your distribution automatically, make sure you
 examine what it generates to make sure it makes sense - indexers will
 usually trust the C<provides> field if it's present, rather than
@@ -482,7 +482,7 @@ directories, packages, and namespaces that are private
 and indexing tools.  This is useful when no C<provides> field is
 present.
 
-For example, C<search.cpan.org> excludes items listed in C<no_index>
+For example, L<http://search.cpan.org/> excludes items listed in C<no_index>
 when searching for POD, meaning files in these directories will not
 converted to HTML and made public - which is useful if you have
 example or test PODs that you don't want the search engine to go
@@ -604,23 +604,23 @@ together using commas.  The specification C<E<gt>= 1.2, != 1.5, E<lt>
 
 =head1 SEE ALSO
 
-CPAN, L<http://www.cpan.org/>
+L<CPAN|http://www.cpan.org/>
 
-CPAN.pm, L<http://search.cpan.org/dist/CPAN/>
+L<CPAN.pm|CPAN>
 
-CPANPLUS, L<http://search.cpan.org/dist/CPANPLUS/>
+L<CPANPLUS>
 
-Data::Dumper, L<http://search.cpan.org/dist/Data-Dumper/>
+L<Data::Dumper>
 
-ExtUtils::MakeMaker, L<http://search.cpan.org/dist/ExtUtils-MakeMaker/>
+L<ExtUtils::MakeMaker>
 
-Module::Build, L<http://search.cpan.org/dist/Module-Build/>
+L<Module::Build>
 
-Module::Install, L<http://search.cpan.org/dist/Module-Install/>
+L<Module::Install>
 
-XML, L<http://www.w3.org/XML/>
+L<XML|http://www.w3.org/XML/>
 
-YAML, L<http://www.yaml.org/>
+L<YAML|http://www.yaml.org/>
 
 =head1 HISTORY
 

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -357,8 +357,8 @@ Example:
 
 I<(Spec 1.1) [optional] {map} A YAML mapping of names for optional features
 which are made available when its requirements are met. For each
-feature a description is provided along with any of L<"requires">,
-L<"build_requires">, and L<"conflicts">, which have the same meaning in
+feature a description is provided along with any of L</requires>,
+L</build_requires>, and L</conflicts>, which have the same meaning in
 this subcontext as described elsewhere in this document.>
 
 =head2 build_requires
@@ -373,7 +373,7 @@ Example:
 prerequisites required for building and/or testing of this
 distribution.  The keys are the names of the prerequisites (module
 names or 'perl'), and the values are version specifications as
-described in L<VERSION SPECIFICATIONS>.  These dependencies are not
+described in L</"VERSION SPECIFICATIONS">.  These dependencies are not
 required after the distribution is installed.
 
 =head2 configure_requires
@@ -387,9 +387,9 @@ Example:
 
 (Spec 1.4) [optional] {map} A YAML mapping indicating the Perl prerequisites
 required before configuring this distribution.  The keys are the
-names of the prerequisites (module names or 'perl'), and the values are version specifications as described
-in L<VERSION SPECIFICATIONS>.  These dependencies are not required
-after the distribution is installed.
+names of the prerequisites (module names or 'perl'), and the values are version
+specifications as described in L</"VERSION SPECIFICATIONS">.  These
+dependencies are not required after the distribution is installed.
 
 =head2 conflicts
 
@@ -403,7 +403,7 @@ Example:
 cannot be installed while this distribution is installed.  This is a
 pretty uncommon situation.  The keys for C<conflicts> are the item
 names (module names or 'perl'), and the values are version
-specifications as described in L<VERSION SPECIFICATIONS>.
+specifications as described in L</"VERSION SPECIFICATIONS">.
 
 
 =head2 dynamic_config
@@ -430,7 +430,7 @@ If this field is omitted, it defaults to 1 (true).
 =head2 private
 
 I<(Deprecated)> (Spec 1.0) [optional] {map} This field has been renamed to
-L</"no_index">.  See below.
+L</no_index>.  See below.
 
 =head2 provides
 
@@ -579,8 +579,8 @@ tool. RWS]
 
 =head1 VERSION SPECIFICATIONS
 
-Some fields require a version specification (ex. L<"requires">,
-L<"recommends">, L<"build_requires">, etc.) to indicate the particular
+Some fields require a version specification (ex. L</requires>,
+L</recommends>, L</build_requires>, etc.) to indicate the particular
 versionZ<>(s) of some other module that may be required as a
 prerequisite.  This section details the version specification formats
 that are currently supported.
@@ -642,7 +642,7 @@ Created version 1.0 of this document.
 
 =item *
 
-Added the L</"dynamic_config"> field, which was missing from the initial
+Added the L</dynamic_config> field, which was missing from the initial
 version.
 
 =back
@@ -662,12 +662,12 @@ L<http://nntp.x.perl.org/group/> site.
 
 =item *
 
-Added and deprecated the L<"private"> field.
+Added and deprecated the L</private> field.
 
 =item *
 
-Added L<"abstract">, L<"configure">, L<"requires_packages">,
-L<"requires_os">, L<"excludes_os">, and L<"no_index"> fields.
+Added L</abstract>, C<configure>, C<requires_packages>,
+C<requires_os>, C<excludes_os>, and L</no_index> fields.
 
 =item *
 
@@ -681,15 +681,15 @@ Bumped version.
 
 =item *
 
-Added L<"generation">, L<"authored_by"> fields.
+Added C<generation>, C<authored_by> fields.
 
 =item *
 
-Add alternative proposal to the L<"recommends"> field.
+Add alternative proposal to the L</recommends> field.
 
 =item *
 
-Add proposal for a L<"requires_build_tools"> field.
+Add proposal for a C<requires_build_tools> field.
 
 =back
 
@@ -703,7 +703,7 @@ Added link to latest version of this specification on CPAN.
 
 =item *
 
-Added section L<"VERSION SPECIFICATIONS">.
+Added section L</"VERSION SPECIFICATIONS">.
 
 =item *
 
@@ -711,7 +711,7 @@ Chang name from Module::Build::META-spec to CPAN::META::Specification.
 
 =item *
 
-Add proposal for L<"auto_regenerate"> field.
+Add proposal for C<auto_regenerate> field.
 
 =back
 
@@ -721,15 +721,15 @@ Add proposal for L<"auto_regenerate"> field.
 
 =item *
 
-Add L<"index"> field as a compliment to L<"no_index">
+Add C<index> field as a compliment to L</no_index>
 
 =item *
 
-Add L<"keywords"> field as a means to aid searching distributions.
+Add L</keywords> field as a means to aid searching distributions.
 
 =item *
 
-Add L<"TERMINOLOGY"> section to explain certain terms that may be
+Add L</TERMINOLOGY> section to explain certain terms that may be
 ambiguous.
 
 =back
@@ -747,7 +747,7 @@ more like records of brainstorming.
 
 =item *
 
-Changed C<authored_by> to C<author>, since that's always been what
+Changed C<authored_by> to L</author>, since that's always been what
 it's actually called in actual F<META.yml> files.
 
 =item *
@@ -757,12 +757,12 @@ operators.
 
 =item *
 
-Noted that the C<distribution_type> field is basically meaningless,
+Noted that the L</distribution_type> field is basically meaningless,
 and shouldn't really be used.
 
 =item *
 
-Clarified C<dynamic_config> a bit.
+Clarified L</dynamic_config> a bit.
 
 =back
 
@@ -783,7 +783,7 @@ module that doesn't actually exist.
 
 =item *
 
-Added C<configure_requires>.
+Added L</configure_requires>.
 
 =back
 

--- a/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -24,6 +24,10 @@ Include list of valid licenses from L<Module::Build> 0.2807 rather than
 linking to the module, with minor updates to text and links to reflect
 versions at the time of publication.
 
+=item *
+
+Fixed some dead links to point to active resources.
+
 =back
 
 =head1 SYNOPSIS


### PR DESCRIPTION
This fixes and cleans up a number of things in the historic meta documents.  It updates the license text and links to point to the specific versions that were relevant at publication time.  It also updates various internal links for changes in the pod spec.  And it updates various external links to point to active resources.