### PR TITLE
CPAN/Meta: add mozilla_2_0

### DIFF
--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -200,6 +200,7 @@ my @valid_licenses_2 = qw(
   mit
   mozilla_1_0
   mozilla_1_1
+  mozilla_2_0
   openssl
   perl_5
   qpl_1_0
@@ -259,6 +260,7 @@ my %license_downgrade_map = qw(
   mit               mit
   mozilla_1_0       mozilla
   mozilla_1_1       mozilla
+  mozilla_2_0       mozilla
   openssl           open_source
   perl_5            perl
   qpl_1_0           open_source

--- a/lib/CPAN/Meta/Spec.pm
+++ b/lib/CPAN/Meta/Spec.pm
@@ -337,6 +337,7 @@ The following list of license strings are valid:
  mit             MIT (aka X11) License
  mozilla_1_0     Mozilla Public License, Version 1.0
  mozilla_1_1     Mozilla Public License, Version 1.1
+ mozilla_2_0     Mozilla Public License, Version 2.0
  openssl         OpenSSL License
  perl_5          The Perl 5 License (Artistic 1 & GPL 1 or later)
  qpl_1_0         Q Public License, Version 1.0

--- a/lib/CPAN/Meta/Validator.pm
+++ b/lib/CPAN/Meta/Validator.pm
@@ -876,6 +876,7 @@ my %v2_licenses = map { $_ => 1 } qw(
   mit
   mozilla_1_0
   mozilla_1_1
+  mozilla_2_0
   openssl
   perl_5
   qpl_1_0


### PR DESCRIPTION
Add mozilla_2_0 to allow better solution for https://github.com/gisle/mozilla-ca/pull/11 (https://rt.cpan.org/Ticket/Display.html?id=97815)

According to https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/files/common-licenses there're a lot of licenses missing. A reasonable number (as n-clause BSD licenses, CC-BY-*, AFL-*, ...) could be easily added.

Just drop me a note and I do at least the low-hangin-fruits.