### PR TITLE
Change search.cpan URLs to MetaCPAN

### DIFF
--- a/corpus/CL018_yaml.meta
+++ b/corpus/CL018_yaml.meta
@@ -9,7 +9,7 @@
       "perl_5"
    ],
    "meta-spec" : {
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec",
       "version" : "2"
    },
    "name" : "Compiler-Lexer",

--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -76,7 +76,7 @@ sub _dclone {
 }
 
 my %known_specs = (
-    '2'   => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+    '2'   => 'https://metacpan.org/pod/CPAN::Meta::Spec',
     '1.4' => 'http://module-build.sourceforge.net/META-spec-v1.4.html',
     '1.3' => 'http://module-build.sourceforge.net/META-spec-v1.3.html',
     '1.2' => 'http://module-build.sourceforge.net/META-spec-v1.2.html',

--- a/lib/CPAN/Meta/Spec.pm
+++ b/lib/CPAN/Meta/Spec.pm
@@ -362,7 +362,7 @@ Example:
 
   'meta-spec' => {
     version => '2',
-    url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+    url     => 'https://metacpan.org/pod/CPAN::Meta::Spec',
   }
 
 (Spec 1.2) [required] {Map}
@@ -391,7 +391,7 @@ For the version 2 spec, either of these are recommended:
 
 =for :list
 * C<https://metacpan.org/pod/CPAN::Meta::Spec>
-* C<http://search.cpan.org/perldoc?CPAN::Meta::Spec>
+* C<https://metacpan.org/pod/CPAN::Meta::Spec>
 
 =back
 

--- a/lib/CPAN/Meta/Spec.pm
+++ b/lib/CPAN/Meta/Spec.pm
@@ -387,11 +387,8 @@ This is a I<URL> of the metadata specification document corresponding to
 the given version.  This is strictly for human-consumption and should
 not impact the interpretation of the document.
 
-For the version 2 spec, either of these are recommended:
-
-=for :list
-* C<https://metacpan.org/pod/CPAN::Meta::Spec>
-* C<https://metacpan.org/pod/CPAN::Meta::Spec>
+For the version 2 spec, C<https://metacpan.org/pod/CPAN::Meta::Spec>
+is recommended.
 
 =back
 

--- a/t/converter-fragments.t
+++ b/t/converter-fragments.t
@@ -11,7 +11,7 @@ delete $ENV{CPAN_META_JSON_DECODER};
 
 my $spec2 = {
     version => '2',
-    url => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+    url => 'https://metacpan.org/pod/CPAN::Meta::Spec',
 };
 
 my @cases = (

--- a/t/data-fail/META-2.json
+++ b/t/data-fail/META-2.json
@@ -7,7 +7,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "name" : "Module-Build",
    "dynamic_config" : 1,

--- a/t/data-fixable/META-2.json
+++ b/t/data-fixable/META-2.json
@@ -7,7 +7,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "version" : "0.36",
    "name" : "Module-Build",

--- a/t/data-fixable/invalid-meta-spec-version.json
+++ b/t/data-fixable/invalid-meta-spec-version.json
@@ -11,7 +11,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "99",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "version" : "0.36",
    "name" : "Module-Build",

--- a/t/data-fixable/meta-spec-version-trailing-zeros.json
+++ b/t/data-fixable/meta-spec-version-trailing-zeros.json
@@ -11,7 +11,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2.0",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "version" : "0.36",
    "name" : "Module-Build",

--- a/t/data-fixable/restrictive-2.json
+++ b/t/data-fixable/restrictive-2.json
@@ -11,7 +11,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "version" : "0.36",
    "name" : "Module-Build",

--- a/t/data-fixable/version-ranges-2.json
+++ b/t/data-fixable/version-ranges-2.json
@@ -2,7 +2,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "abstract" : "stuff",
    "version" : "0.36",

--- a/t/data-test/META-2.json
+++ b/t/data-test/META-2.json
@@ -11,7 +11,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "version" : "0.36",
    "name" : "Module-Build",

--- a/t/data-test/provides-version-missing.json
+++ b/t/data-test/provides-version-missing.json
@@ -11,7 +11,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "version" : "0.36",
    "name" : "Module-Build",

--- a/t/data-test/restricted-2.json
+++ b/t/data-test/restricted-2.json
@@ -11,7 +11,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "version" : "0.36",
    "name" : "Module-Build",

--- a/t/data-test/version-not-normal.json
+++ b/t/data-test/version-not-normal.json
@@ -2,7 +2,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "abstract" : "stuff",
    "version" : "0.36",

--- a/t/data-test/version-ranges-2.json
+++ b/t/data-test/version-ranges-2.json
@@ -2,7 +2,7 @@
    "generated_by" : "Module::Build version 0.36",
    "meta-spec" : {
       "version" : "2",
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec"
    },
    "abstract" : "stuff",
    "version" : "0.36",

--- a/t/data-test/x_deprecated-META.json
+++ b/t/data-test/x_deprecated-META.json
@@ -22,7 +22,7 @@
       "perl_5"
    ],
    "meta-spec" : {
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec",
       "version" : 2
    },
    "name" : "Dist-Zilla-Plugin-Test-EOL",

--- a/t/data-valid/META-2.json
+++ b/t/data-valid/META-2.json
@@ -19,7 +19,7 @@
       "perl_5"
    ],
    "meta-spec" : {
-      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec",
       "version" : "2"
    },
    "name" : "Module-Build",

--- a/t/merge.t
+++ b/t/merge.t
@@ -33,7 +33,7 @@ my %base = (
 		},
 	},
 	'meta-spec' => {
-		url => "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+		url => "https://metacpan.org/pod/CPAN::Meta::Spec",
 		version => 2,
 	},
 );
@@ -101,7 +101,7 @@ my %first_expected = (
 	},
 	dynamic_config => 1,
 	'meta-spec' => {
-		url => "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+		url => "https://metacpan.org/pod/CPAN::Meta::Spec",
 		version => 2,
 	},
 );
@@ -129,7 +129,7 @@ my %provides_merge_expected = (
 		},
 	},
 	'meta-spec' => {
-		url => "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+		url => "https://metacpan.org/pod/CPAN::Meta::Spec",
 		version => 2,
 	},
 );

--- a/t/meta-obj.t
+++ b/t/meta-obj.t
@@ -70,7 +70,7 @@ my $distmeta = {
   keywords => [ qw/ toolchain cpan dual-life / ],
   'meta-spec' => {
     version => '2',
-    url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+    url     => 'https://metacpan.org/pod/CPAN::Meta::Spec',
   },
   generated_by => 'Module::Build version 0.36',
   x_authority => 'cpan:FLORA',
@@ -148,7 +148,7 @@ is_deeply(
   $meta->meta_spec,
   {
     version => '2',
-    url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+    url     => 'https://metacpan.org/pod/CPAN::Meta::Spec',
   },
   '->meta_spec',
 );

--- a/t/no-index.t
+++ b/t/no-index.t
@@ -18,7 +18,7 @@ my %distmeta = (
   license  => [ 'perl_5' ],
   'meta-spec' => {
     version => '2',
-    url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+    url     => 'https://metacpan.org/pod/CPAN::Meta::Spec',
   },
   dynamic_config => 1,
   generated_by   => 'Module::Build version 0.36',

--- a/t/optional_feature-merge.t
+++ b/t/optional_feature-merge.t
@@ -32,7 +32,7 @@ my %base = (
 		},
 	},
 	'meta-spec' => {
-		url => "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+		url => "https://metacpan.org/pod/CPAN::Meta::Spec",
 		version => 2,
 	},
 );

--- a/t/save-load.t
+++ b/t/save-load.t
@@ -70,7 +70,7 @@ my $distmeta = {
   keywords => [ qw/ toolchain cpan dual-life / ],
   'meta-spec' => {
     version => '2',
-    url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+    url     => 'https://metacpan.org/pod/CPAN::Meta::Spec',
   },
   generated_by => 'Module::Build version 0.36',
 };


### PR DESCRIPTION
As you probably already know search.cpan.org is due to be [decommissioned](https://log.perl.org/2018/05/goodbye-search-dot-cpan-dot-org.html). While redirects will be in place for existing links, this PR changes the URLs from search.cpan to their metacpan equivalent.