### PR TITLE
Don't normalize versions in provides hash

### DIFF
--- a/lib/CPAN/Meta/Converter.pm
+++ b/lib/CPAN/Meta/Converter.pm
@@ -392,12 +392,7 @@ sub _clean_version {
   my $v = eval { version->new($element) };
   # XXX check defined $v and not just $v because version objects leak memory
   # in boolean context -- dagolden, 2012-02-03
-  if ( defined $v ) {
-    return _is_qv($v) ? $v->normal : $element;
-  }
-  else {
-    return 0;
-  }
+  return defined $v ? $v->stringify : 0;
 }
 
 sub _bad_version_hook {


### PR DESCRIPTION
If a file is provided as an alpha version, it should be represented in the provides hash as such.

See also https://github.com/briandfoy/cpan-mini-inject/issues/11